### PR TITLE
Add new converters and preserve reference names when converting identifiers in value mode

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -349,6 +349,7 @@ Object {
                   },
                 },
               ],
+              "referenceIdName": "b",
             },
             "property": Object {
               "kind": "id",
@@ -1340,6 +1341,7 @@ Object {
             "callee": Object {
               "kind": "id",
               "name": "sayHello",
+              "referenceIdName": "sayHello",
               "type": null,
             },
             "kind": "call",
@@ -1657,8 +1659,7 @@ Object {
               "name": "Date",
               "type": null,
             },
-            "isConstructor": true,
-            "kind": "call",
+            "kind": "new",
           },
           "key": "a",
           "kind": "property",

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1328,6 +1328,41 @@ Object {
 }
 `;
 
+exports[`function declaration 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "default": Object {
+            "args": Array [],
+            "callee": Object {
+              "kind": "id",
+              "name": "sayHello",
+              "type": null,
+            },
+            "kind": "call",
+          },
+          "key": "a",
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "string",
+          },
+        },
+      ],
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`function expression 1`] = `
 Object {
   "classes": Array [
@@ -1593,6 +1628,46 @@ Object {
             "parameters": Array [],
             "returnType": Object {
               "kind": "mixed",
+            },
+          },
+        },
+      ],
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`new expression 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "default": Object {
+            "args": Array [],
+            "callee": Object {
+              "kind": "id",
+              "name": "Date",
+              "type": null,
+            },
+            "isConstructor": true,
+            "kind": "call",
+          },
+          "key": "a",
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "generic",
+            "value": Object {
+              "kind": "id",
+              "name": "Date",
             },
           },
         },

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1346,7 +1346,10 @@ Object {
             },
             "kind": "call",
           },
-          "key": "a",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1661,7 +1664,10 @@ Object {
             },
             "kind": "new",
           },
-          "key": "a",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {

--- a/index.js
+++ b/index.js
@@ -224,6 +224,14 @@ converters.CallExpression = (path, context) => {
   };
 };
 
+converters.NewExpression = (path, context) => {
+  const convertedCallExpression = converters.CallExpression(path, context);
+  return {
+    ...convertedCallExpression,
+    isConstructor: true,
+  }
+};
+
 converters.TypeofTypeAnnotation = (path, context) => {
   let type = convert(path.get("argument"), context);
   return {
@@ -431,6 +439,13 @@ converters.ObjectExpression = (path, context) => {
     members
   };
 };
+
+converters.FunctionDeclaration = (path, context) => {
+  return {
+    kind: "FunctionDeclaration",
+    id: convert(path.get("id"), context),
+  };
+}
 
 converters.VariableDeclaration = (path, context) => {
   let res = {};

--- a/index.js
+++ b/index.js
@@ -493,7 +493,11 @@ converters.Identifier = (path, context) => {
             `Unable to resolve binding path for: ${bindingPath.type}`
           );
         }
-        return convert(foundPath, context);
+        const convertedValue = convert(foundPath, context);
+        return {
+          ...convertedValue,
+          referenceIdName: path.node.name,
+        };
       } else {
         let type = null;
 

--- a/index.js
+++ b/index.js
@@ -134,6 +134,19 @@ converters.AssignmentPattern = (path, context) => {
   };
 };
 
+converters.ObjectPattern = (path, context) => {
+  let properties = [];
+
+  for (const property of properties) {
+    properties.push(convert(property, context));
+  }
+
+  return {
+    kind: "ObjectPattern",
+    properties,
+  }
+}
+
 converters.ClassDeclaration = (path, context) => {
   if (!isReactComponentClass(path)) {
     return {

--- a/test.js
+++ b/test.js
@@ -733,7 +733,6 @@ const TESTS = [
     `
   },
   {
-    only: true,
     name: "non-standard key with default",
     typeSystem: "flow",
     code: `
@@ -743,7 +742,31 @@ const TESTS = [
         }
       }
     `
-  }
+  },
+  {
+    name: "new expression",
+    typeSystem: "flow",
+    code: `
+      class Component extends React.Component<{ a: Date }> {
+        defaultProps = {
+          a: new Date()
+        }
+      }
+    `
+  },
+  {
+    name: "function declaration",
+    typeSystem: "flow",
+    code: `
+      function sayHello() { return 'hello'; };
+
+      class Component extends React.Component<{ a: string }> {
+        defaultProps = {
+          a: sayHello(),
+        }
+      }
+    `
+  },
 ];
 
 for (let testCase of TESTS) {


### PR DESCRIPTION
These are needed for the Atlaskit CalendarStateless prop documentation.