### PR TITLE
Replace non-existent format babel-log function with ast-pretty-print

### DIFF
--- a/matchExported.js
+++ b/matchExported.js
@@ -1,7 +1,7 @@
 // @flow
 const { explodeModule } = require("babel-explode-module");
 const { explodedToStatements } = require("babel-helper-simplify-module");
-const { format } = require("babel-log");
+const printAST = require('ast-pretty-print');
 const t = require("babel-types");
 
 module.exports = function matchExported(
@@ -43,11 +43,11 @@ module.exports = function matchExported(
     } else if (item.node.id) {
       id = item.node.id;
     } else {
-      throw new Error(`Unexpected node:\n\n${format(item)}`);
+      throw new Error(`Unexpected node:\n\n${printAST(item)}`);
     }
 
     if (!id) {
-      throw new Error(`Couldn't find id on node:\n\n${format(item)}`);
+      throw new Error(`Couldn't find id on node:\n\n${printAST(item)}`);
     }
 
     return id.name === local;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "ast-pretty-print": "^2.0.1",
     "babel-core": "7.0.0-alpha.19",
     "babel-errors": "^1.1.1",
     "babel-explode-module": "^2.0.0",
@@ -18,7 +19,6 @@
     "babel-flow-scope": "^1.2.1",
     "babel-helper-simplify-module": "^2.2.0",
     "babel-identifiers": "^1.1.2",
-    "babel-log": "^2.0.0",
     "babel-normalize-comments": "^1.0.1",
     "babel-react-components": "^1.1.0",
     "babel-types": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,7 +138,7 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-ast-pretty-print@^2.0.0:
+ast-pretty-print@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ast-pretty-print/-/ast-pretty-print-2.0.1.tgz#e3a0f443b8f9414d7925dea18d125362e4f6a372"
   dependencies:
@@ -357,12 +357,6 @@ babel-jest@^21.2.0:
   dependencies:
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "^21.2.0"
-
-babel-log@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/babel-log/-/babel-log-2.0.0.tgz#9925f99521d3d3ccb5839c0a31120291dd1ba638"
-  dependencies:
-    ast-pretty-print "^2.0.0"
 
 babel-messages@7.0.0-alpha.19:
   version "7.0.0-alpha.19"


### PR DESCRIPTION
The format function in babel-log was removed in v2. I've replaced it with it's replacement within babel-log, ast-pretty-print.