### PR TITLE
Parse object key

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -7,34 +7,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "async": false,
-            "generator": false,
-            "id": null,
-            "kind": "function",
-            "parameters": Array [
-              Object {
-                "kind": "param",
-                "type": null,
-                "value": Object {
-                  "kind": "AssignmentPattern",
-                  "left": Object {
-                    "kind": "id",
-                    "name": "b",
-                    "type": null,
-                  },
-                  "right": Object {
-                    "kind": "number",
-                    "value": 3,
-                  },
-                },
-              },
-            ],
-            "returnType": Object {
-              "kind": "number",
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -68,7 +44,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "a",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -102,7 +81,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "a",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -128,16 +110,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "elements": Array [
-              Object {
-                "kind": "string",
-                "value": "a",
-              },
-            ],
-            "kind": "array",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -175,17 +151,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "async": false,
-            "generator": false,
-            "id": null,
-            "kind": "function",
-            "parameters": Array [],
-            "returnType": Object {
-              "kind": "number",
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -215,19 +184,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "binary",
-            "left": Object {
-              "kind": "number",
-              "value": 3,
-            },
-            "operator": "+",
-            "right": Object {
-              "kind": "number",
-              "value": 5,
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -253,11 +213,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "boolean",
-            "value": true,
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -283,59 +242,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "memberExpression",
-            "object": Object {
-              "kind": "object",
-              "members": Array [
-                Object {
-                  "key": Object {
-                    "kind": "id",
-                    "name": "c",
-                    "type": null,
-                  },
-                  "kind": "property",
-                  "value": Object {
-                    "async": false,
-                    "generator": false,
-                    "id": null,
-                    "kind": "function",
-                    "parameters": Array [
-                      Object {
-                        "kind": "param",
-                        "type": Object {
-                          "kind": "string",
-                        },
-                        "value": Object {
-                          "kind": "id",
-                          "name": "a",
-                        },
-                      },
-                      Object {
-                        "kind": "param",
-                        "type": Object {
-                          "kind": "string",
-                        },
-                        "value": Object {
-                          "kind": "id",
-                          "name": "b",
-                        },
-                      },
-                    ],
-                    "returnType": Object {
-                      "kind": "number",
-                    },
-                  },
-                },
-              ],
-            },
-            "property": Object {
-              "kind": "id",
-              "name": "c",
-              "type": null,
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -365,17 +275,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "async": false,
-            "generator": false,
-            "id": null,
-            "kind": "function",
-            "parameters": Array [],
-            "returnType": Object {
-              "kind": "exists",
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -405,7 +308,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "age",
+          "key": Object {
+            "kind": "id",
+            "name": "age",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -431,7 +337,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -469,7 +378,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -515,7 +427,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -541,7 +456,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": true,
           "value": Object {
@@ -559,7 +477,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": true,
           "value": Object {
@@ -585,7 +506,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -614,7 +538,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -651,7 +578,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -688,7 +618,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -722,7 +655,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -752,7 +688,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -789,7 +728,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -799,7 +741,10 @@ Object {
                 "kind": "object",
                 "members": Array [
                   Object {
-                    "key": "prop",
+                    "key": Object {
+                      "kind": "id",
+                      "name": "prop",
+                    },
                     "kind": "property",
                     "optional": false,
                     "value": Object {
@@ -860,7 +805,10 @@ Object {
         "kind": "object",
         "members": Array [
           Object {
-            "key": "children",
+            "key": Object {
+              "kind": "id",
+              "name": "children",
+            },
             "kind": "property",
             "optional": false,
             "value": Object {
@@ -888,7 +836,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -917,7 +868,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "age",
+          "key": Object {
+            "kind": "id",
+            "name": "age",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -950,7 +904,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -976,7 +933,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": true,
           "value": Object {
@@ -1002,7 +962,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1035,7 +998,10 @@ Object {
         "kind": "object",
         "members": Array [
           Object {
-            "key": "foo",
+            "key": Object {
+              "kind": "id",
+              "name": "foo",
+            },
             "kind": "property",
             "optional": false,
             "value": Object {
@@ -1043,7 +1009,10 @@ Object {
             },
           },
           Object {
-            "key": "bar",
+            "key": Object {
+              "kind": "id",
+              "name": "bar",
+            },
             "kind": "property",
             "optional": false,
             "value": Object {
@@ -1065,7 +1034,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1106,7 +1078,10 @@ Object {
         "kind": "object",
         "members": Array [
           Object {
-            "key": "children",
+            "key": Object {
+              "kind": "id",
+              "name": "children",
+            },
             "kind": "property",
             "optional": false,
             "value": Object {
@@ -1132,7 +1107,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1166,7 +1144,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "age",
+          "key": Object {
+            "kind": "id",
+            "name": "age",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1201,7 +1182,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1227,17 +1211,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "async": false,
-            "generator": false,
-            "id": null,
-            "kind": "function",
-            "parameters": Array [],
-            "returnType": Object {
-              "kind": "number",
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1267,20 +1244,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "memberExpression",
-            "object": Object {
-              "kind": "id",
-              "name": "b",
-              "type": null,
-            },
-            "property": Object {
-              "kind": "id",
-              "name": "c",
-              "type": null,
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1310,20 +1277,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "memberExpression",
-            "object": Object {
-              "kind": "id",
-              "name": "b",
-              "type": null,
-            },
-            "property": Object {
-              "kind": "id",
-              "name": "c",
-              "type": null,
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1353,20 +1310,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "memberExpression",
-            "object": Object {
-              "kind": "id",
-              "name": "b",
-              "type": null,
-            },
-            "property": Object {
-              "kind": "id",
-              "name": "c",
-              "type": null,
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1406,7 +1353,10 @@ Object {
             "kind": "object",
             "members": Array [
               Object {
-                "key": "bar",
+                "key": Object {
+                  "kind": "id",
+                  "name": "bar",
+                },
                 "kind": "property",
                 "optional": false,
                 "value": Object {
@@ -1420,7 +1370,10 @@ Object {
           "kind": "object",
           "members": Array [
             Object {
-              "key": "isDefaultChecked",
+              "key": Object {
+                "kind": "id",
+                "name": "isDefaultChecked",
+              },
               "kind": "property",
               "optional": false,
               "value": Object {
@@ -1443,20 +1396,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "memberExpression",
-            "object": Object {
-              "kind": "id",
-              "name": "b",
-              "type": null,
-            },
-            "property": Object {
-              "kind": "id",
-              "name": "c",
-              "type": null,
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1486,7 +1429,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "ab-a",
+          "key": Object {
+            "kind": "string",
+            "value": "ab-a",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1494,7 +1440,10 @@ Object {
           },
         },
         Object {
-          "key": "a",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
+          },
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1520,10 +1469,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "null",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": true,
           "value": Object {
@@ -1549,11 +1498,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "number",
-            "value": 5,
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1579,11 +1527,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "boolean",
-            "value": true,
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1591,11 +1538,10 @@ Object {
           },
         },
         Object {
-          "default": Object {
-            "kind": "boolean",
-            "value": false,
+          "key": Object {
+            "kind": "id",
+            "name": "b",
           },
-          "key": "b",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1621,11 +1567,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "string",
-            "value": "stringVal",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1651,23 +1596,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "templateExpression",
-            "tag": Object {
-              "kind": "memberExpression",
-              "object": Object {
-                "kind": "id",
-                "name": "styled",
-                "type": null,
-              },
-              "property": Object {
-                "kind": "id",
-                "name": "div",
-                "type": null,
-              },
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1697,7 +1629,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "key": "foo",
+          "key": Object {
+            "kind": "id",
+            "name": "foo",
+          },
           "kind": "property",
           "optional": true,
           "value": Object {
@@ -1727,33 +1662,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "JSXElement",
-            "value": Object {
-              "attributes": Array [
-                Object {
-                  "kind": "JSXAttribute",
-                  "name": Object {
-                    "kind": "JSXIdentifier",
-                    "value": "name",
-                  },
-                  "value": Object {
-                    "kind": "JSXExpressionContainer",
-                    "value": Object {
-                      "kind": "string",
-                      "value": "test icon",
-                    },
-                  },
-                },
-              ],
-              "kind": "JSXOpeningElement",
-              "name": Object {
-                "kind": "JSXIdentifier",
-                "value": "Icon",
-              },
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1785,33 +1697,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "JSXElement",
-            "value": Object {
-              "attributes": Array [
-                Object {
-                  "kind": "JSXAttribute",
-                  "name": Object {
-                    "kind": "JSXIdentifier",
-                    "value": "name",
-                  },
-                  "value": Object {
-                    "kind": "JSXExpressionContainer",
-                    "value": Object {
-                      "kind": "string",
-                      "value": "test icon",
-                    },
-                  },
-                },
-              ],
-              "kind": "JSXOpeningElement",
-              "name": Object {
-                "kind": "JSXIdentifier",
-                "value": "Icon",
-              },
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1843,40 +1732,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "JSXElement",
-            "value": Object {
-              "attributes": Array [
-                Object {
-                  "kind": "JSXAttribute",
-                  "name": Object {
-                    "kind": "JSXIdentifier",
-                    "value": "name",
-                  },
-                  "value": Object {
-                    "kind": "JSXExpressionContainer",
-                    "value": Object {
-                      "kind": "string",
-                      "value": "test icon",
-                    },
-                  },
-                },
-              ],
-              "kind": "JSXOpeningElement",
-              "name": Object {
-                "kind": "JSXMemberExpression",
-                "object": Object {
-                  "kind": "JSXIdentifier",
-                  "value": "componentObj",
-                },
-                "property": Object {
-                  "kind": "JSXIdentifier",
-                  "value": "Icon",
-                },
-              },
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1908,41 +1767,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "JSXElement",
-            "value": Object {
-              "attributes": Array [
-                Object {
-                  "kind": "JSXAttribute",
-                  "name": Object {
-                    "kind": "JSXIdentifier",
-                    "value": "name",
-                  },
-                  "value": Object {
-                    "kind": "string",
-                    "value": "test icon",
-                  },
-                },
-                Object {
-                  "kind": "JSXAttribute",
-                  "name": Object {
-                    "kind": "JSXIdentifier",
-                    "value": "iconType",
-                  },
-                  "value": Object {
-                    "kind": "string",
-                    "value": "avatar",
-                  },
-                },
-              ],
-              "kind": "JSXOpeningElement",
-              "name": Object {
-                "kind": "JSXIdentifier",
-                "value": "Icon",
-              },
-            },
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -1974,11 +1802,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "kind": "string",
-            "value": "a",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -2365,15 +2192,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
-          "default": Object {
-            "argument": Object {
-              "kind": "number",
-              "value": 1,
-            },
-            "kind": "unary",
-            "operator": "-",
+          "key": Object {
+            "kind": "id",
+            "name": "a",
           },
-          "key": "a",
           "kind": "property",
           "optional": false,
           "value": Object {
@@ -2413,7 +2235,10 @@ Object {
                 "kind": "object",
                 "members": Array [
                   Object {
-                    "key": "foo",
+                    "key": Object {
+                      "kind": "id",
+                      "name": "foo",
+                    },
                     "kind": "property",
                     "optional": false,
                     "value": Object {
@@ -2425,7 +2250,10 @@ Object {
             },
           },
           Object {
-            "key": "isDefaultChecked",
+            "key": Object {
+              "kind": "id",
+              "name": "isDefaultChecked",
+            },
             "kind": "property",
             "optional": false,
             "value": Object {

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -7,6 +7,33 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "async": false,
+            "generator": false,
+            "id": null,
+            "kind": "function",
+            "parameters": Array [
+              Object {
+                "kind": "param",
+                "type": null,
+                "value": Object {
+                  "kind": "AssignmentPattern",
+                  "left": Object {
+                    "kind": "id",
+                    "name": "b",
+                    "type": null,
+                  },
+                  "right": Object {
+                    "kind": "number",
+                    "value": 3,
+                  },
+                },
+              },
+            ],
+            "returnType": Object {
+              "kind": "number",
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -110,6 +137,15 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "elements": Array [
+              Object {
+                "kind": "string",
+                "value": "a",
+              },
+            ],
+            "kind": "array",
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -151,6 +187,16 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "async": false,
+            "generator": false,
+            "id": null,
+            "kind": "function",
+            "parameters": Array [],
+            "returnType": Object {
+              "kind": "number",
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -184,6 +230,18 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "binary",
+            "left": Object {
+              "kind": "number",
+              "value": 3,
+            },
+            "operator": "+",
+            "right": Object {
+              "kind": "number",
+              "value": 5,
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -213,6 +271,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "boolean",
+            "value": true,
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -242,6 +304,58 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "memberExpression",
+            "object": Object {
+              "kind": "object",
+              "members": Array [
+                Object {
+                  "key": Object {
+                    "kind": "id",
+                    "name": "c",
+                    "type": null,
+                  },
+                  "kind": "property",
+                  "value": Object {
+                    "async": false,
+                    "generator": false,
+                    "id": null,
+                    "kind": "function",
+                    "parameters": Array [
+                      Object {
+                        "kind": "param",
+                        "type": Object {
+                          "kind": "string",
+                        },
+                        "value": Object {
+                          "kind": "id",
+                          "name": "a",
+                        },
+                      },
+                      Object {
+                        "kind": "param",
+                        "type": Object {
+                          "kind": "string",
+                        },
+                        "value": Object {
+                          "kind": "id",
+                          "name": "b",
+                        },
+                      },
+                    ],
+                    "returnType": Object {
+                      "kind": "number",
+                    },
+                  },
+                },
+              ],
+            },
+            "property": Object {
+              "kind": "id",
+              "name": "c",
+              "type": null,
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -275,6 +389,16 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "async": false,
+            "generator": false,
+            "id": null,
+            "kind": "function",
+            "parameters": Array [],
+            "returnType": Object {
+              "kind": "exists",
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1211,6 +1335,16 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "async": false,
+            "generator": false,
+            "id": null,
+            "kind": "function",
+            "parameters": Array [],
+            "returnType": Object {
+              "kind": "number",
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1244,6 +1378,19 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "memberExpression",
+            "object": Object {
+              "kind": "id",
+              "name": "b",
+              "type": null,
+            },
+            "property": Object {
+              "kind": "id",
+              "name": "c",
+              "type": null,
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1277,6 +1424,19 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "memberExpression",
+            "object": Object {
+              "kind": "id",
+              "name": "b",
+              "type": null,
+            },
+            "property": Object {
+              "kind": "id",
+              "name": "c",
+              "type": null,
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1310,6 +1470,19 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "memberExpression",
+            "object": Object {
+              "kind": "id",
+              "name": "b",
+              "type": null,
+            },
+            "property": Object {
+              "kind": "id",
+              "name": "c",
+              "type": null,
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1396,6 +1569,19 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "memberExpression",
+            "object": Object {
+              "kind": "id",
+              "name": "b",
+              "type": null,
+            },
+            "property": Object {
+              "kind": "id",
+              "name": "c",
+              "type": null,
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1462,6 +1648,50 @@ Object {
 }
 `;
 
+exports[`non-standard key with default 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "default": Object {
+            "kind": "number",
+            "value": 37,
+          },
+          "key": Object {
+            "kind": "string",
+            "value": "ab-a",
+          },
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "number",
+          },
+        },
+        Object {
+          "key": Object {
+            "kind": "id",
+            "name": "a",
+          },
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "number",
+          },
+        },
+      ],
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`null literal 1`] = `
 Object {
   "classes": Array [
@@ -1469,6 +1699,9 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "null",
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1498,6 +1731,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "number",
+            "value": 5,
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1527,6 +1764,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "boolean",
+            "value": true,
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1538,6 +1779,10 @@ Object {
           },
         },
         Object {
+          "default": Object {
+            "kind": "boolean",
+            "value": false,
+          },
           "key": Object {
             "kind": "id",
             "name": "b",
@@ -1567,6 +1812,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "string",
+            "value": "stringVal",
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1596,6 +1845,22 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "templateExpression",
+            "tag": Object {
+              "kind": "memberExpression",
+              "object": Object {
+                "kind": "id",
+                "name": "styled",
+                "type": null,
+              },
+              "property": Object {
+                "kind": "id",
+                "name": "div",
+                "type": null,
+              },
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1662,6 +1927,32 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "JSXElement",
+            "value": Object {
+              "attributes": Array [
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "name",
+                  },
+                  "value": Object {
+                    "kind": "JSXExpressionContainer",
+                    "value": Object {
+                      "kind": "string",
+                      "value": "test icon",
+                    },
+                  },
+                },
+              ],
+              "kind": "JSXOpeningElement",
+              "name": Object {
+                "kind": "JSXIdentifier",
+                "value": "Icon",
+              },
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1697,6 +1988,32 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "JSXElement",
+            "value": Object {
+              "attributes": Array [
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "name",
+                  },
+                  "value": Object {
+                    "kind": "JSXExpressionContainer",
+                    "value": Object {
+                      "kind": "string",
+                      "value": "test icon",
+                    },
+                  },
+                },
+              ],
+              "kind": "JSXOpeningElement",
+              "name": Object {
+                "kind": "JSXIdentifier",
+                "value": "Icon",
+              },
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1732,6 +2049,39 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "JSXElement",
+            "value": Object {
+              "attributes": Array [
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "name",
+                  },
+                  "value": Object {
+                    "kind": "JSXExpressionContainer",
+                    "value": Object {
+                      "kind": "string",
+                      "value": "test icon",
+                    },
+                  },
+                },
+              ],
+              "kind": "JSXOpeningElement",
+              "name": Object {
+                "kind": "JSXMemberExpression",
+                "object": Object {
+                  "kind": "JSXIdentifier",
+                  "value": "componentObj",
+                },
+                "property": Object {
+                  "kind": "JSXIdentifier",
+                  "value": "Icon",
+                },
+              },
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1767,6 +2117,40 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "JSXElement",
+            "value": Object {
+              "attributes": Array [
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "name",
+                  },
+                  "value": Object {
+                    "kind": "string",
+                    "value": "test icon",
+                  },
+                },
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "iconType",
+                  },
+                  "value": Object {
+                    "kind": "string",
+                    "value": "avatar",
+                  },
+                },
+              ],
+              "kind": "JSXOpeningElement",
+              "name": Object {
+                "kind": "JSXIdentifier",
+                "value": "Icon",
+              },
+            },
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -1802,6 +2186,10 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "kind": "string",
+            "value": "a",
+          },
           "key": Object {
             "kind": "id",
             "name": "a",
@@ -2192,6 +2580,14 @@ Object {
       "kind": "object",
       "members": Array [
         Object {
+          "default": Object {
+            "argument": Object {
+              "kind": "number",
+              "value": 1,
+            },
+            "kind": "unary",
+            "operator": "-",
+          },
           "key": Object {
             "kind": "id",
             "name": "a",

--- a/index.js
+++ b/index.js
@@ -18,12 +18,20 @@ const matchExported = require("./matchExported");
 const converters = {};
 
 const getPropFromObject = (obj, property) => {
-  if (!property.key || !property.key.name) {
-    return;
-    // look into resolving this. It's types being returned instead of idents...
-    // more, the with leadinComments etc, very weird
+  // The kind of the object member must be the same as the kind of the property
+  if (property.key.kind === "id") {
+    return obj.members.find(p => p.key.name === property.key.name);
+  } else if (property.key.kind === "string") {
+    return obj.members.find(p => p.key.value === property.key.value);
+  } else {
+    throw new Error(
+      JSON.stringify({
+        error: "could not find property to go with default",
+        default: property,
+        properties: obj.members
+      })
+    );
   }
-  return obj.members.find(p => p.key === property.key.name);
 };
 
 const resolveFromGeneric = type => {
@@ -97,7 +105,7 @@ function convertReactComponentClass(path, context) {
     defaultProps.value.members.forEach(property => {
       let ungeneric = resolveFromGeneric(classProperties);
       const prop = getProp(ungeneric, property);
-      if (prop) prop.default = property.value;
+      prop.default = property.value;
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -346,17 +346,9 @@ converters.ObjectTypeAnnotation = (path, context) => {
 };
 
 converters.ObjectTypeProperty = (path, context) => {
-  let key = path.get("key");
-  let keyName = "";
-  if (key.type === "Identifier") {
-    keyName = key.node.name;
-  } else if (key.type === "StringLiteral") {
-    keyName = key.node.value;
-  }
-
   let result = {};
   result.kind = "property";
-  result.key = keyName;
+  result.key = convert(path.get("key"), context);
   result.value = convert(path.get("value"), context);
   result.optional = path.node.optional;
   return result;
@@ -520,11 +512,11 @@ converters.Identifier = (path, context) => {
       let bindingPath;
 
       if (isFlowIdentifier(path)) {
-        let flowBinding = findFlowBinding(path, path.node.name);
+        let flowBinding = findFlowBinding(path, name);
         if (!flowBinding) throw new Error();
         bindingPath = flowBinding.path.parentPath;
       } else {
-        bindingPath = path.scope.getBinding(path.node.name);
+        bindingPath = path.scope.getBinding(name);
       }
 
       if (bindingPath) {
@@ -533,8 +525,10 @@ converters.Identifier = (path, context) => {
         }
         if (bindingPath.kind !== "module") return convert(bindingPath, context);
       } else {
-        return { kind: "id", name: path.node.name };
+        return { kind: "id", name: name };
       }
+    } else if (kind === "static" || kind === "binding") {
+      return { kind: "id", name };
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-react-types",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "index.js",
   "repository": "atlassian/extract-react-types",
   "author": "James Kyle <me@thejameskyle.com>",

--- a/test.js
+++ b/test.js
@@ -714,16 +714,14 @@ const TESTS = [
     name: "BooleanLiteralTypeAnnotation",
     typeSystem: "flow",
     code: `
-      class Component extends React.Component<{a: string => true}> {
-      }
+      class Component extends React.Component<{a: string => true}> {}
     `
   },
   {
     name: "NullLiteralTypeAnnotation",
     typeSystem: "flow",
     code: `
-      class Component extends React.Component<{a: null}> {
-      }
+      class Component extends React.Component<{a: null}> {}
     `
   },
   {
@@ -731,6 +729,18 @@ const TESTS = [
     typeSystem: "flow",
     code: `
       class Component extends React.Component<{ 'ab-a': number, a: number }> {
+      }
+    `
+  },
+  {
+    only: true,
+    name: "non-standard key with default",
+    typeSystem: "flow",
+    code: `
+      class Component extends React.Component<{ 'ab-a': number, a: number }> {
+        defaultProps = {
+          'ab-a': 37,
+        }
       }
     `
   }


### PR DESCRIPTION
Change `ObjectTypeProperty` to convert keys instead of assuming they are an identifier and just applying the name.

NB: This is a breaking change to consumers