### PR TITLE
add support for TypeParameterDeclaration and TypeParameter

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1406,6 +1406,59 @@ Object {
 }
 `;
 
+exports[`flow type parameter declaration 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "key": Object {
+            "kind": "id",
+            "name": "a",
+          },
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "generic",
+            "typeParams": Object {
+              "kind": "typeParams",
+              "params": Array [
+                Object {
+                  "kind": "string",
+                },
+              ],
+            },
+            "value": Object {
+              "kind": "function",
+              "parameters": Array [],
+              "returnType": Object {
+                "kind": "generic",
+                "value": Object {
+                  "kind": "typeParamsDeclaration",
+                  "params": Array [
+                    Object {
+                      "kind": "typeParam",
+                      "name": "T",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ],
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`flow union 1`] = `
 Object {
   "classes": Array [

--- a/index.js
+++ b/index.js
@@ -489,6 +489,23 @@ converters.TypeParameterInstantiation = (path, context) /*: K.TypeParams*/ => {
   };
 };
 
+converters.TypeParameterDeclaration = (
+  path,
+  context
+) /*: K.TypeParamsDeclaration */ => {
+  return {
+    kind: 'typeParamsDeclaration',
+    params: path.get('params').map(p => convert(p, context))
+  };
+};
+
+converters.TypeParameter = (path, context) /*: K.TypeParam */ => {
+  return {
+    kind: 'typeParam',
+    name: path.node.name
+  };
+};
+
 converters.GenericTypeAnnotation = (path, context) /*: K.Generic*/ => {
   let result = {};
 

--- a/kinds.js
+++ b/kinds.js
@@ -7,6 +7,11 @@ export type Param = {
   type: AnyKind | null
 };
 export type TypeParams = { kind: "typeParams", params: Array<AnyTypeKind> };
+export type TypeParam = { kind: "typeParam", name: string };
+export type TypeParamsDeclaration = {
+  kind: "typeParamsDeclaration",
+  params: Array<AnyTypeKind>
+};
 export type Id = { kind: "id", name: string, type?: ?$Diff<AnyKind, Id> };
 export type TemplateLiteral = {
   kind: "templateLiteral",

--- a/test.js
+++ b/test.js
@@ -831,6 +831,15 @@ const TESTS = [
 
       class Component extends React.Component<{ a: typeof one }> {}
   `
+  },
+  {
+    name: 'flow type parameter declaration',
+    typeSystem: 'flow',
+    code: `
+      type Foo<T> = () => T;
+
+      class Component extends React.Component<{ a: Foo<string> }> {}
+  `
   }
 ];
 


### PR DESCRIPTION
Desired support:
```js
      type Foo<T> = () => T;

      class Component extends React.Component<{ a: Foo<string> }> {}
```

([AST Explorer for this example](https://astexplorer.net/#/gist/b5fd8296d03aadb48a9decfba5492c83/587c8ee8ea5713e4dcd0ae80731b19198fbeedba))

Output:
```js
 Missing converter for: TypeParameterDeclaration

      at convert (index.js:1032:25)
      at Object.<anonymous>.converters.Identifier (index.js:661:51)
      at convert (index.js:1033:16)
      at Object.<anonymous>.converters.GenericTypeAnnotation (index.js:496:18)
      at convert (index.js:1033:16)
      at Object.<anonymous>.converters.FunctionTypeAnnotation (index.js:731:22)
      at convert (index.js:1033:16)
      at Object.<anonymous>.converters.TypeAlias (index.js:673:10)
      at convert (index.js:1033:16)
      at Object.<anonymous>.converters.Identifier (index.js:661:51)
      ...
```

This PR adds support for TypeParameterDeclaration and TypeParameter.