### PR TITLE
Fix generic object spread

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -4033,6 +4033,72 @@ Object {
 }
 `;
 
+exports[`with generic spread in type annotation and default props 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "generic",
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+      "value": Object {
+        "kind": "object",
+        "members": Array [
+          Object {
+            "kind": "spread",
+            "value": Object {
+              "kind": "generic",
+              "typeParams": Object {
+                "kind": "typeParams",
+                "params": Array [
+                  Object {
+                    "kind": "generic",
+                    "value": Object {
+                      "kind": "object",
+                      "members": Array [
+                        Object {
+                          "key": Object {
+                            "kind": "id",
+                            "name": "foo",
+                          },
+                          "kind": "property",
+                          "optional": false,
+                          "value": Object {
+                            "kind": "string",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              "value": Object {
+                "kind": "id",
+                "name": "$Exact",
+              },
+            },
+          },
+          Object {
+            "key": Object {
+              "kind": "id",
+              "name": "isDefaultChecked",
+            },
+            "kind": "property",
+            "optional": false,
+            "value": Object {
+              "kind": "boolean",
+            },
+          },
+        ],
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`with spread in type annotation 1`] = `
 Object {
   "classes": Array [

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -4075,3 +4075,50 @@ Object {
   "kind": "program",
 }
 `;
+
+exports[`with spread in type annotation and default props 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "generic",
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+      "value": Object {
+        "kind": "object",
+        "members": Array [
+          Object {
+            "default": Object {
+              "kind": "string",
+              "value": "abc",
+            },
+            "key": Object {
+              "kind": "id",
+              "name": "foo",
+            },
+            "kind": "property",
+            "optional": false,
+            "value": Object {
+              "kind": "string",
+            },
+          },
+          Object {
+            "key": Object {
+              "kind": "id",
+              "name": "isDefaultChecked",
+            },
+            "kind": "property",
+            "optional": false,
+            "value": Object {
+              "kind": "boolean",
+            },
+          },
+        ],
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ const getPropFromObject = (props, property) => {
 
   props.members.forEach(p => {
     if (p.kind === 'spread') {
-      let p2 = getPropFromObject(p.value.value, property);
+      let spreadArg = resolveFromGeneric(p.value);
+      if (!spreadArg || spreadArg.kind !== 'object') return;
+      let p2 = getPropFromObject(spreadArg, property);
       if (p2) prop = p2;
       // The kind of the object member must be the same as the kind of the property
     } else if (property.key.kind === 'id' && p.key.name === property.key.name) {
@@ -155,13 +157,7 @@ function convertReactComponentClass(path, context) {
     let ungeneric = resolveFromGeneric(classProperties);
     const prop = getProp(ungeneric, property);
     if (!prop) {
-      throw new Error(
-        JSON.stringify(
-          `could not find property to go with default of ${
-            property.key.value ? property.key.value : property.key.name
-          } in ${classProperties.name}`
-        )
-      );
+      return;
     }
     prop.default = property.value;
   });

--- a/test.js
+++ b/test.js
@@ -248,6 +248,38 @@ const TESTS = [
   `
   },
   {
+    name: 'with spread in type annotation and default props',
+    typeSystem: 'flow',
+    code: `
+  type BaseProps = { foo: string }
+  type Props = {
+    ...BaseProps,
+    isDefaultChecked: boolean,
+  }
+  class Component extends React.Component<Props> {
+    static defaultProps = {
+      foo: 'abc',
+    };
+  }
+  `
+  },
+  {
+    name: 'with generic spread in type annotation and default props',
+    typeSystem: 'flow',
+    code: `
+  type BaseProps = { foo: string }
+  type Props = {
+    ...$Exact<BaseProps>,
+    isDefaultChecked: boolean,
+  }
+  class Component extends React.Component<Props> {
+    static defaultProps = {
+      foo: 'abc',
+    };
+  }
+  `
+  },
+  {
     name: 'flow array union',
     typeSystem: 'flow',
     code: `


### PR DESCRIPTION
An error is thrown when prop types contain an object spread and default props exist on the component.

I've updated `getPropFromObject` to not attempt to retrieve object properties from non-objects when encountering a spread and removed the error that is thrown when a default prop value is not found as I don't think we want to throw an error if we can't find the corresponding prop for a default value.

Generic spreads still aren't parsed properly (they don't show up in our prop type defs) so I want to address that in a subsequent PR.

The major use case for supporting generic spreads are:

1. Wrapping an object in `$Exact<>` when spreading it so it doesn't convert all subsequent props to optional/mixed values.
2. Extending the props of another component but taking into account it's default props by using [ElementConfig](https://flow.org/en/docs/react/types/#toc-react-elementconfig).

The error (and generic spreads not being parsed properly) are blocking https://bitbucket.org/atlassian/atlaskit-mk-2/pull-requests/3750.