### PR TITLE
feat: add support for TSIndexedAccessType and fix TSQualifiedName for imported types

### DIFF
--- a/index.js
+++ b/index.js
@@ -826,6 +826,23 @@ converters.NullableTypeAnnotation = (path, context) /*: K.Nullable*/ => {
   };
 };
 
+converters.TSIndexedAccessType = (path, context) => {
+  const type = convert(path.get('objectType'), context);
+  const indexKey = path.get('indexType').node.literal.value;
+
+  if (type.kind === 'generic') {
+    return {
+      kind: 'generic',
+      value: {
+        kind: type.value.kind,
+        name: `${type.value.name}['${indexKey}']`
+      }
+    };
+  } else {
+    throw new Error(`Unsupported TSIndexedAccessType kind: ${type.kind}`)
+  }
+}
+
 converters.TSStringKeyword = (path) /*: K.String */ => {
   return { kind: 'string' };
 };
@@ -971,7 +988,7 @@ converters.TSQualifiedName = (path, context) /*: K.Id */ => {
 
   return {
     kind: 'id',
-    name: `${left.name}.${right.name}`
+    name: `${left.name || left.referenceIdName}.${right.name}`
   };
 };
 


### PR DESCRIPTION
Fixes issue where React imported types would be `undefined.TypeName` and adds support for TS type index lookup `const a: MyType['myKey']`