### PR TITLE
update the extract react types loader to pull types from types file i…

### DIFF
--- a/.changeset/early-flies-ring/changes.json
+++ b/.changeset/early-flies-ring/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "extract-react-types-loader", "type": "patch" }], "dependents": [] }

--- a/.changeset/early-flies-ring/changes.md
+++ b/.changeset/early-flies-ring/changes.md
@@ -1,0 +1,1 @@
+Don't pull types from src if types file exits

--- a/packages/extract-react-types-loader/index.js
+++ b/packages/extract-react-types-loader/index.js
@@ -47,7 +47,12 @@ module.exports = function extractReactTypesLoader(content /* : string */) {
 
   const resolveOpts = {
     pathFilter: (pkg, location, dist) => {
-      if (pkg['atlaskit:src'] && location.includes('node_modules') && location.includes(pkg.main)) {
+      if (
+        !pkg.types &&
+        pkg['atlaskit:src'] &&
+        location.includes('node_modules') &&
+        location.includes(pkg.main)
+      ) {
         return location.replace(dist, pkg['atlaskit:src']);
       }
       return null;


### PR DESCRIPTION
…f present for external modules.

### What does it solve?

We are adding CJS support in the PR https://bitbucket.org/atlassian/atlaskit-mk-2/pull-requests/5938, which actually breaks Extract-react-types since, typescript package (badge and dynamic table as example) is loading types from flow packages (theme and analytics for example). Since, the loader start with typescript is actually and then tries to load the source file which from other package which is actually flow and blows.

### About the fix

Stops extract-react-types to pull types from source if types file is already available. I am not 100% how that works internally but my understanding is it pull types from types entry is don't force it pull from `['atlaskit:src']`, which is what this PR does.