### PR TITLE
Handle type casting in TypeScript (as)

### DIFF
--- a/.changeset/silver-dots-exercise/changes.json
+++ b/.changeset/silver-dots-exercise/changes.json
@@ -1,0 +1,21 @@
+{
+  "releases": [{ "name": "extract-react-types", "type": "minor" }],
+  "dependents": [
+    {
+      "name": "babel-plugin-extract-react-types",
+      "type": "patch",
+      "dependencies": ["extract-react-types"]
+    },
+    {
+      "name": "extract-react-types-loader",
+      "type": "patch",
+      "dependencies": ["extract-react-types"]
+    },
+    { "name": "kind2string", "type": "patch", "dependencies": ["extract-react-types"] },
+    {
+      "name": "pretty-proptypes",
+      "type": "patch",
+      "dependencies": ["kind2string", "extract-react-types"]
+    }
+  ]
+}

--- a/.changeset/silver-dots-exercise/changes.md
+++ b/.changeset/silver-dots-exercise/changes.md
@@ -1,0 +1,1 @@
+Adds support for TypeScript's as expression.

--- a/packages/extract-react-types/__snapshots__/test.js.snap
+++ b/packages/extract-react-types/__snapshots__/test.js.snap
@@ -3889,6 +3889,55 @@ Object {
 }
 `;
 
+exports[`ts as expression 1`] = `
+Object {
+  "component": Object {
+    "kind": "generic",
+    "name": Object {
+      "kind": "id",
+      "name": "Component",
+      "type": null,
+    },
+    "value": Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "default": Object {
+            "kind": "string",
+            "value": "foo",
+          },
+          "key": Object {
+            "kind": "id",
+            "name": "bar",
+          },
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "generic",
+            "value": Object {
+              "kind": "union",
+              "referenceIdName": "Foo",
+              "types": Array [
+                Object {
+                  "kind": "string",
+                  "value": "foo",
+                },
+                Object {
+                  "kind": "string",
+                  "value": "bar",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "referenceIdName": "Props",
+    },
+  },
+  "kind": "program",
+}
+`;
+
 exports[`ts boolean 1`] = `
 Object {
   "component": Object {

--- a/packages/extract-react-types/src/index.js
+++ b/packages/extract-react-types/src/index.js
@@ -1188,6 +1188,10 @@ converters.TSThisType = (path, context): K.This => {
   return { kind: 'custom', value: 'this' };
 };
 
+converters.TSAsExpression = (path, context): K.Param => {
+  return convert(path.get('expression'), context);
+};
+
 function extendedTypesMembers(path, context) {
   const members = path.get('extends');
   if (!members || !members.length) {

--- a/packages/extract-react-types/test.js
+++ b/packages/extract-react-types/test.js
@@ -504,6 +504,20 @@ const TESTS = [
   `
   },
   {
+    name: 'ts as expression',
+    typeSystem: 'typescript',
+    code: `
+    type Foo = 'foo' | 'bar';
+    type Props = { bar: Foo }
+
+    class Component extends React.Component<Props> {
+      static defaultProps = {
+        bar: 'foo' as Foo,
+      }
+    }
+  `
+  },
+  {
     name: 'ts object',
     typeSystem: 'typescript',
     code: `


### PR DESCRIPTION
## What? 
Adds support for TypeScript's `as` expression.

## Why? 
In TypeScript you can encounter the following scenario when using `union` strings.

```typescript
type Foo = 'foo' | 'bar';
interface Props {  bar: Foo; }

const foo: string = 'foo';
const props: Props = {
  bar: foo as Foo,
}
```

Which yields an error: `Type 'string' is not assignable to type 'Foo'.`

In React this scenario occurs when you have union-typed props and you assign a static string value as a default value:

```typescirpt
type Foo = 'foo' | 'bar';

class Component extends React.Component<{ a: Foo }> {
  static defaultProps = {
    a: 'foo' as Foo,
  }
}
```