### PR TITLE
Workaround for null typescript definitions

### DIFF
--- a/.changeset/two-impalas-compare/changes.json
+++ b/.changeset/two-impalas-compare/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "extract-react-types", "type": "patch" }], "dependents": [] }

--- a/.changeset/two-impalas-compare/changes.md
+++ b/.changeset/two-impalas-compare/changes.md
@@ -1,0 +1,1 @@
+Introduces a workaround for TypeScript types that are unable to be resolved and return null 

--- a/packages/extract-react-types/src/index.js
+++ b/packages/extract-react-types/src/index.js
@@ -218,6 +218,14 @@ function convertReactComponentClass(path, context) {
     ...context,
     mode: 'value'
   });
+
+  /**
+   * FIXME: It's possible to get nulls in the members array when TS is unable
+   * to resolve type definitions of non-relative module imports
+   * See: https://github.com/atlassian/extract-react-types/issues/89
+   **/
+  classProperties.value.members = classProperties.value.members.filter(m => !!m);
+
   return addDefaultProps(classProperties, defaultProps);
 }
 


### PR DESCRIPTION
This PR is a temporary workaround for this issue: https://github.com/atlassian/extract-react-types/issues/89

