### PR TITLE
ensure members exist before attempting to filter

### DIFF
--- a/.changeset/poor-maps-hang/changes.json
+++ b/.changeset/poor-maps-hang/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "extract-react-types", "type": "patch" }], "dependents": [] }

--- a/.changeset/poor-maps-hang/changes.md
+++ b/.changeset/poor-maps-hang/changes.md
@@ -1,0 +1,1 @@
+Fix to ensure members exist before attempting to filter them

--- a/packages/extract-react-types/src/index.js
+++ b/packages/extract-react-types/src/index.js
@@ -224,7 +224,9 @@ function convertReactComponentClass(path, context) {
    * to resolve type definitions of non-relative module imports
    * See: https://github.com/atlassian/extract-react-types/issues/89
    **/
-  classProperties.value.members = classProperties.value.members.filter(m => !!m);
+  if (classProperties.value.members) {
+    classProperties.value.members = classProperties.value.members.filter(m => !!m);
+  }
 
   return addDefaultProps(classProperties, defaultProps);
 }


### PR DESCRIPTION
It's possible for members not to exist on the value object. 
Added a check to ensure it doesn't throw