### PR TITLE
resolve thrown error on null values in members array, add tests

### DIFF
--- a/packages/pretty-proptypes/src/PrettyConvert/converters.js
+++ b/packages/pretty-proptypes/src/PrettyConvert/converters.js
@@ -104,7 +104,7 @@ export const converters: { [string]: ?Function } = {
     if (type.members.length === 0) {
       return <components.Type>Object</components.Type>;
     }
-    let simpleObj = type.members.filter(mem => !SIMPLE_TYPES.includes(mem.kind)).length === 0;
+    let simpleObj = type.members.filter(mem => mem && !SIMPLE_TYPES.includes(mem.kind)).length === 0;
 
     if (simpleObj) {
       return <components.Type>{convert(type)}</components.Type>;
@@ -114,7 +114,7 @@ export const converters: { [string]: ?Function } = {
       <span>
         <AddBrackets BracketStyler={components.TypeMeta} openBracket="{" closeBracket="}">
           <components.Indent>
-            {type.members.map(prop => {
+            {type.members.filter(p => p).map(prop => {
               if (prop.kind === 'spread') {
                 const nestedObj = resolveFromGeneric(prop.value);
                 // Spreads almost always resolve to an object, but they can
@@ -236,5 +236,6 @@ const prettyConvert = (type: K.AnyKind, components: Components, depth: number = 
   }
   return converter(type, components, depth);
 };
+
 
 export default prettyConvert;

--- a/packages/pretty-proptypes/src/PrettyConvert/converters.js
+++ b/packages/pretty-proptypes/src/PrettyConvert/converters.js
@@ -104,7 +104,14 @@ export const converters: { [string]: ?Function } = {
     if (type.members.length === 0) {
       return <components.Type>Object</components.Type>;
     }
-    let simpleObj = type.members.filter(mem => mem && !SIMPLE_TYPES.includes(mem.kind)).length === 0;
+    let simpleObj = type.members.filter(mem => {
+      if (mem === null) {
+        /** if the member is null, error out */
+        console.error(`null property in members of ${type.referenceIdName} of kind ${type.kind} `)
+        return false;
+      }
+      return !SIMPLE_TYPES.includes(mem.kind)
+    }).length === 0;
 
     if (simpleObj) {
       return <components.Type>{convert(type)}</components.Type>;

--- a/packages/pretty-proptypes/src/PrettyConvert/converters.test.js
+++ b/packages/pretty-proptypes/src/PrettyConvert/converters.test.js
@@ -122,9 +122,35 @@ test('resolve generic of array', () => {
   expect(wrapper.html().includes('string')).toBeTruthy();
 });
 
+test('objects with null members do not throw', () => {
+  const type = {
+    kind: "object",
+    members: [
+      {
+        kind: "property",
+        optional: false,
+        key: {
+          kind: "id",
+          name: "children"
+        },
+        value: {
+          kind: "generic",
+          value: {
+            kind: "id",
+            name: "React.ReactNode"
+          }
+        }
+      },
+      null
+    ],
+    referenceIdName: "LabelTextProps"
+  }
+  expect(() => prettyConvert(type, components)).not.toThrow();
+})
+
 test.skip('object with spread object', () => {
   let values = getSingleDefault(`{ ...something, c: 'something' }`);
-  let wrapper = shallow(prettyConvert(values, components));
+  let wrapper = shallow(prettyConvert(`{ ...something, c: 'something' }`, components));
   expect(wrapper).toBe('something');
 });
 test.skip('resolve generic of array with complex type', () => {


### PR DESCRIPTION
Related to @danieldelcore's work on null member properties. 
Null member properties are a result of yet unresolved typescript types in ERT,

This is a small work around to ensure that in these scenarios an exception isn't thrown, and the program isn't terminated.  