### PR TITLE
change console.error to console.warn

### DIFF
--- a/.changeset/three-rats-begin/changes.json
+++ b/.changeset/three-rats-begin/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "pretty-proptypes", "type": "patch" }], "dependents": [] }

--- a/.changeset/three-rats-begin/changes.md
+++ b/.changeset/three-rats-begin/changes.md
@@ -1,0 +1,1 @@
+Change console.error for null members in pretty-proptypes to console.warn

--- a/packages/pretty-proptypes/src/PrettyConvert/converters.js
+++ b/packages/pretty-proptypes/src/PrettyConvert/converters.js
@@ -107,7 +107,7 @@ export const converters: { [string]: ?Function } = {
     let simpleObj = type.members.filter(mem => {
       if (mem === null) {
         /** if the member is null, error out */
-        console.error(`null property in members of ${type.referenceIdName} of kind ${type.kind} `)
+        console.warn(`null property in members of ${type.referenceIdName} of kind ${type.kind} `)
         return false;
       }
       return !SIMPLE_TYPES.includes(mem.kind)


### PR DESCRIPTION
This is causing a ruckus on the atlaskit/website, changing to a console.warn for now