### PR TITLE
Change scopes

### DIFF
--- a/.changeset/lemon-tips-sing/changes.json
+++ b/.changeset/lemon-tips-sing/changes.json
@@ -1,0 +1,10 @@
+{
+  "releases": [
+    { "name": "@extract-types/babel-plugin-extract-react-types", "type": "patch" },
+    { "name": "@extract-types/loader", "type": "patch" },
+    { "name": "@extract-types/core", "type": "patch" },
+    { "name": "@extract-types/kind2string", "type": "patch" },
+    { "name": "@extract-types/pretty-proptypes", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/lemon-tips-sing/changes.md
+++ b/.changeset/lemon-tips-sing/changes.md
@@ -1,0 +1,1 @@
+Added @extract-types scope to packages, with slight rename for sense

--- a/packages/babel-plugin-extract-react-types/package.json
+++ b/packages/babel-plugin-extract-react-types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel-plugin-extract-react-types",
+  "name": "@extract-types/babel-plugin-extract-react-types",
   "version": "0.1.6",
   "main": "index.js",
   "license": "MIT",

--- a/packages/extract-react-types-loader/package.json
+++ b/packages/extract-react-types-loader/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "extract-react-types-loader",
+  "name": "@extract-types/loader",
   "version": "0.3.9",
   "main": "index.js",
   "repository": "atlassian/extract-react-types",

--- a/packages/extract-react-types/package.json
+++ b/packages/extract-react-types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "extract-react-types",
+  "name": "@extract-types/core",
   "version": "0.22.1",
   "main": "dist/extract-react-types.cjs.js",
   "repository": "atlassian/extract-react-types",

--- a/packages/kind2string/package.json
+++ b/packages/kind2string/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kind2string",
+  "name": "@extract-types/kind2string",
   "version": "0.6.3",
   "main": "dist/kind2string.cjs.js",
   "module": "dist/kind2string.esm.js",

--- a/packages/pretty-proptypes/package.json
+++ b/packages/pretty-proptypes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pretty-proptypes",
+  "name": "@extract-types/pretty-proptypes",
   "version": "1.0.1",
   "description": "prettily render prop types from react components",
   "repository": "atlassian/extract-react-types",


### PR DESCRIPTION
* Added @extract-types as scope to all packages. 
* extract-react-types now @extract-types/core
* kind2string now @extract-types/kind2string
* pretty-proptypes now @extract-types/pretty-proptypes
* extract-react-types-loader now @extract-types/loader
* babel-plugin-extract-react-types now @extract-types/babel-plugin-extract-react-types
