### PR TITLE
Follow export { default } 

### DIFF
--- a/.changeset/hip-wasps-lay/changes.json
+++ b/.changeset/hip-wasps-lay/changes.json
@@ -1,0 +1,21 @@
+{
+  "releases": [{ "name": "extract-react-types", "type": "minor" }],
+  "dependents": [
+    {
+      "name": "babel-plugin-extract-react-types",
+      "type": "patch",
+      "dependencies": ["extract-react-types"]
+    },
+    {
+      "name": "extract-react-types-loader",
+      "type": "patch",
+      "dependencies": ["extract-react-types"]
+    },
+    { "name": "kind2string", "type": "patch", "dependencies": ["extract-react-types"] },
+    {
+      "name": "pretty-proptypes",
+      "type": "patch",
+      "dependencies": ["kind2string", "extract-react-types"]
+    }
+  ]
+}

--- a/.changeset/hip-wasps-lay/changes.md
+++ b/.changeset/hip-wasps-lay/changes.md
@@ -1,0 +1,1 @@
+Update ert to resolve export { default } to a relevant react component

--- a/packages/extract-react-types/__fixtures__/component.tsx
+++ b/packages/extract-react-types/__fixtures__/component.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+type Props = {
+  className?: string
+}
+export default ({ className }: Props) => <div className={className} />

--- a/packages/extract-react-types/__fixtures__/componentB.tsx
+++ b/packages/extract-react-types/__fixtures__/componentB.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+type Props = {
+  className?: string
+}
+export const x = ({ className }: Props) => <div className={className} />

--- a/packages/extract-react-types/__snapshots__/test.js.snap
+++ b/packages/extract-react-types/__snapshots__/test.js.snap
@@ -2623,6 +2623,39 @@ Object {
 }
 `;
 
+exports[`follow export { default }  1`] = `
+Object {
+  "component": Object {
+    "kind": "generic",
+    "value": Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "key": Object {
+            "kind": "id",
+            "name": "className",
+          },
+          "kind": "property",
+          "optional": true,
+          "value": Object {
+            "kind": "string",
+          },
+        },
+      ],
+      "referenceIdName": "Props",
+    },
+  },
+  "kind": "program",
+}
+`;
+
+exports[`follow export { default }  2`] = `
+Object {
+  "component": undefined,
+  "kind": "program",
+}
+`;
+
 exports[`function declaration 1`] = `
 Object {
   "component": Object {

--- a/packages/extract-react-types/src/findExports.js
+++ b/packages/extract-react-types/src/findExports.js
@@ -42,7 +42,7 @@ export default function findExports(
   path
     .get('body')
     .filter(bodyPath =>
-      // we only check for named and default exports here, we don't want export all)
+      // we only check for named and default exports here, we don't want export all
       exportsToFind === 'default'
         ? bodyPath.isExportDefaultDeclaration()
         : (bodyPath.isExportNamedDeclaration() &&

--- a/packages/extract-react-types/src/findExports.js
+++ b/packages/extract-react-types/src/findExports.js
@@ -37,9 +37,9 @@ export default function findExports(
 
   path
     .get('body')
-    .filter(bodyPath => {
+    .filter(bodyPath => 
       // we only check for named and default exports here, we don't want export all)
-      return exportsToFind === 'default'
+      exportsToFind === 'default'
         ? bodyPath.isExportDefaultDeclaration()
         : (bodyPath.isExportNamedDeclaration() &&
             bodyPath.node.source === null &&
@@ -47,8 +47,8 @@ export default function findExports(
             (bodyPath.node.exportKind === 'value' ||
               // exportKind is undefined in typescript
               bodyPath.node.exportKind === undefined)) ||
-          bodyPath.isExportDefaultDeclaration();
-    })
+          bodyPath.isExportDefaultDeclaration()
+    )
     .forEach(exportPath => {
       const declaration = exportPath.get('declaration');
 

--- a/packages/extract-react-types/src/findExports.js
+++ b/packages/extract-react-types/src/findExports.js
@@ -1,23 +1,27 @@
 import { loadFileSync, resolveImportFilePathSync } from 'babel-file-loader';
-export function hasDestructuredDefaultExport (path) {
+export function hasDestructuredDefaultExport(path) {
   const exportPath = path.get('body').find(bodyPath => {
-    return bodyPath.isExportNamedDeclaration() 
-      && bodyPath.get('specifiers')
-        .filter(n => n.node.exported.name === 'default').length;
+    return (
+      bodyPath.isExportNamedDeclaration() &&
+      bodyPath.get('specifiers').filter(n => n.node.exported.name === 'default').length
+    );
   });
 
   return Boolean(exportPath);
 }
 
-export function followExports (path, context, convert) {
-  const exportPath = path.get('body')
-    .find(bodyPath => {
-      return bodyPath.isExportNamedDeclaration() && bodyPath.get('specifiers').filter(n => n.node.exported.name === 'default');
-    })
-  
-  if (!exportPath) throw new Error({
-    message: 'No export path found' 
+export function followExports(path, context, convert) {
+  const exportPath = path.get('body').find(bodyPath => {
+    return (
+      bodyPath.isExportNamedDeclaration() &&
+      bodyPath.get('specifiers').filter(n => n.node.exported.name === 'default')
+    );
   });
+
+  if (!exportPath)
+    throw new Error({
+      message: 'No export path found'
+    });
 
   try {
     const filePath = resolveImportFilePathSync(exportPath, context.resolveOptions);
@@ -31,13 +35,13 @@ export function followExports (path, context, convert) {
 
 export default function findExports(
   path,
-  exportsToFind: 'all' | 'default',
+  exportsToFind: 'all' | 'default'
 ): Array<{ name: string | null, path: any }> {
   let formattedExports = [];
 
   path
     .get('body')
-    .filter(bodyPath => 
+    .filter(bodyPath =>
       // we only check for named and default exports here, we don't want export all)
       exportsToFind === 'default'
         ? bodyPath.isExportDefaultDeclaration()

--- a/packages/extract-react-types/src/index.js
+++ b/packages/extract-react-types/src/index.js
@@ -348,7 +348,7 @@ converters.Program = (path, context): K.Program => {
   // only do so on export { default } from 'x';
   // followExports(path, context, convert);
   if (hasDestructuredDefaultExport(path, context)) {
-    return followExports(path, context, convert); 
+    return followExports(path, context, convert);
   } else {
     let components = exportedComponents(path, 'default', context);
     // components[0] could be undefined
@@ -1566,7 +1566,7 @@ export function extractReactTypes(
   return convert(file.path, { resolveOptions, parserOpts });
 }
 
-function exportedComponents(programPath, componentsToFind: 'all' | 'default') {
+function exportedComponents(programPath, componentsToFind: 'all' | 'default', context) {
   let components = [];
 
   findExports(programPath, componentsToFind).forEach(({ path, name }) => {

--- a/packages/extract-react-types/src/index.js
+++ b/packages/extract-react-types/src/index.js
@@ -1566,10 +1566,10 @@ export function extractReactTypes(
   return convert(file.path, { resolveOptions, parserOpts });
 }
 
-function exportedComponents(programPath, componentsToFind: 'all' | 'default', context) {
+function exportedComponents(programPath, componentsToFind: 'all' | 'default') {
   let components = [];
 
-  findExports(programPath, componentsToFind, context).forEach(({ path, name }) => {
+  findExports(programPath, componentsToFind).forEach(({ path, name }) => {
     if (
       path.isFunctionExpression() ||
       path.isArrowFunctionExpression() ||

--- a/packages/extract-react-types/test.js
+++ b/packages/extract-react-types/test.js
@@ -1686,7 +1686,7 @@ const TESTS = [
     code: `
       export { default } from './__fixtures__/component.tsx';
     `
-  }, 
+  },
   {
     name: 'follow export { default } ',
     typeSystem: 'typescript',
@@ -1703,7 +1703,7 @@ const specificTestCases = [
     code: `
       export { default } from './__fixtures__/component.tsx';
     `
-  }, 
+  },
   {
     name: 'follow export { default } ',
     typeSystem: 'typescript',

--- a/packages/extract-react-types/test.js
+++ b/packages/extract-react-types/test.js
@@ -1679,6 +1679,37 @@ const TESTS = [
     class Component extends React.Component<Props> {
     }
   `
+  },
+  {
+    name: 'follow export { default } ',
+    typeSystem: 'typescript',
+    code: `
+      export { default } from './__fixtures__/component.tsx';
+    `
+  }, 
+  {
+    name: 'follow export { default } ',
+    typeSystem: 'typescript',
+    code: `
+      export { x as default } from './__fixtures__/componentB.tsx';
+    `
+  }
+];
+
+const specificTestCases = [
+  {
+    name: 'follow export { default } ',
+    typeSystem: 'typescript',
+    code: `
+      export { default } from './__fixtures__/component.tsx';
+    `
+  }, 
+  {
+    name: 'follow export { default } ',
+    typeSystem: 'typescript',
+    code: `
+      export { x as default } from './__fixtures__/componentB.tsx';
+    `
   }
 ];
 


### PR DESCRIPTION
What it says on the tin. 
We now have logic for resolving a file with 
```jsx
export { default } from './x' 
```
to its relevant react component and types