### PR TITLE
feat(pretty-proptypes): handle generic prop typings

### DIFF
--- a/.changeset/eighty-months-smile.md
+++ b/.changeset/eighty-months-smile.md
@@ -1,0 +1,5 @@
+---
+'pretty-proptypes': minor
+---
+
+add generic prop interface handling in pretty-proptypes

--- a/packages/pretty-proptypes/src/getPropTypes.js
+++ b/packages/pretty-proptypes/src/getPropTypes.js
@@ -9,7 +9,12 @@ const getPropTypes = (propTypesObj: Kind) => {
     propTypes = resolvedTypes.members;
   } else if (resolvedTypes.kind === 'intersection') {
     propTypes = resolvedTypes.types.reduce((acc, type) => [...acc, ...reduceToObj(type)], []);
+  } else if (resolvedTypes.kind === 'generic') {
+    const { value } = resolvedTypes;
+
+    propTypes = value && value.members;
   }
+
   return propTypes;
 };
 


### PR DESCRIPTION
- add generic proptype interface handling for such cases:
```typescript
interface FormProps<FormData> {
  children: () => ReactNode;
  onSubmit: OnSubmitHandler<FormData>;
  /* When set the form and all fields will be disabled */
  isDisabled?: boolean;
}
function Form<FormData extends Record<string, any> = {}>(
  props: FormProps<FormData>,
) {}
```
- [x] Test against atlaskit