### PR TITLE
Add jsx pragma

### DIFF
--- a/.changeset/smooth-moons-cheer.md
+++ b/.changeset/smooth-moons-cheer.md
@@ -1,0 +1,5 @@
+---
+'pretty-proptypes': patch
+---
+
+Add missing jsx pragma in `packages/pretty-proptypes/src/PropsTable/index.js` which fixes an erroneous `css` attribute being rendered.

--- a/.changeset/smooth-moons-cheer.md
+++ b/.changeset/smooth-moons-cheer.md
@@ -2,4 +2,4 @@
 'pretty-proptypes': patch
 ---
 
-Add missing jsx pragma in `packages/pretty-proptypes/src/PropsTable/index.js` which fixes an erroneous `css` attribute being rendered.
+Add missing jsx pragma in `packages/pretty-proptypes/src/PropsTable/index.js` which fixes an erroneous `css` attribute being rendered in prop table `tr`'s.

--- a/packages/pretty-proptypes/src/PropsTable/index.js
+++ b/packages/pretty-proptypes/src/PropsTable/index.js
@@ -2,6 +2,8 @@
 
 /* eslint-disable no-underscore-dangle */
 
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
 import React, { Component, type ComponentType } from 'react';
 
 import type { Components } from '../components';
@@ -70,9 +72,11 @@ export default class PropsTable extends Component<DynamicPropsProps> {
       <PropsWrapper heading={heading}>
         <table>
           <thead>
-            <tr css={{
-              paddingTop: '14px',
-            }}>
+            <tr
+              css={{
+                paddingTop: '14px'
+              }}
+            >
               <td>Name</td>
               <td>Type</td>
               <td>Defaults</td>


### PR DESCRIPTION
Add a missing jsx pragma and jsx import to a file which was missing it and trying to use emotion's css prop. This was resulting in an erroneous css attribute being rendered:
![image](https://user-images.githubusercontent.com/9005422/102732231-43645d00-438e-11eb-9c80-3524eebd852f.png)
