### PR TITLE
DST-1321 Prop opt out

### DIFF
--- a/.changeset/wise-bulldogs-repeat.md
+++ b/.changeset/wise-bulldogs-repeat.md
@@ -1,5 +1,8 @@
 ---
 'extract-react-types': minor
+'babel-plugin-extract-react-types': patch
+'kind2string': patch
 ---
 
-Added the ability to 'ignore' a property to avoid the missing converter error. To ignore a property add a comment above the prop and prefix it with @ert-ignore.
+Added a safe bail-out for when extract-react-types encounters an unsupported keyword or syntax.
+In that case, the type will be output as a raw string and summary type will be `unsupported`.

--- a/.changeset/wise-bulldogs-repeat.md
+++ b/.changeset/wise-bulldogs-repeat.md
@@ -1,0 +1,5 @@
+---
+'extract-react-types': minor
+---
+
+Added the ability to 'ignore' a property to avoid the missing converter error. To ignore a property add a comment above the prop and prefix it with @ert-ignore.

--- a/.changeset/wise-bulldogs-repeat.md
+++ b/.changeset/wise-bulldogs-repeat.md
@@ -5,4 +5,4 @@
 ---
 
 Added a safe bail-out for when extract-react-types encounters an unsupported keyword or syntax.
-In that case, the type will be output as a raw string and summary type will be `unsupported`.
+In that case, the type will be output as a raw string and summary type will be `raw`.

--- a/packages/babel-plugin-extract-react-types/index.js
+++ b/packages/babel-plugin-extract-react-types/index.js
@@ -9,10 +9,11 @@ module.exports = babel => {
           .map(plugin => (Array.isArray(plugin) ? plugin[0] : plugin))
           .find(plugin => plugin === 'flow' || plugin === 'typescript');
 
-        if (typeSystem) {
-          try {
-            let components = findExportedComponents(programPath, typeSystem, state.file.filename);
-            components.forEach(({ name, component }) => {
+        if (!typeSystem) return;
+
+        try {
+          findExportedComponents(programPath, typeSystem, state.file.filename).forEach(
+            ({ name, component }) => {
               // TODO: handle when name is null
               // it will only happen when it's the default export
               // generate something like this
@@ -28,10 +29,10 @@ module.exports = babel => {
                   )
                 );
               }
-            });
-            /* eslint-disable no-empty */
-          } catch (e) {}
-        }
+            }
+          );
+          /* eslint-disable no-empty */
+        } catch (e) {}
       }
     }
   };

--- a/packages/extract-react-types/__snapshots__/converters-typescript.test.js.snap
+++ b/packages/extract-react-types/__snapshots__/converters-typescript.test.js.snap
@@ -28,72 +28,6 @@ Object {
 }
 `;
 
-exports[`TypeScript: Ignores unsupported typescript keywords 1`] = `
-Object {
-  "kind": "generic",
-  "name": Object {
-    "kind": "id",
-    "name": "Component",
-    "type": null,
-  },
-  "value": Object {
-    "kind": "object",
-    "members": Array [
-      Object {
-        "key": Object {
-          "kind": "id",
-          "name": "bar",
-        },
-        "kind": "property",
-        "leadingComments": Array [
-          Object {
-            "raw": " @ert-ignore bar property, ignored because of unknown type ",
-            "type": "commentBlock",
-            "value": "bar property, ignored because of unknown type",
-          },
-        ],
-        "optional": false,
-        "value": undefined,
-      },
-    ],
-    "referenceIdName": "BarProps",
-  },
-}
-`;
-
-exports[`TypeScript: Ignores unsupported typescript keywords type props 1`] = `
-Object {
-  "kind": "generic",
-  "name": Object {
-    "kind": "id",
-    "name": "Component",
-    "type": null,
-  },
-  "value": Object {
-    "kind": "object",
-    "members": Array [
-      Object {
-        "key": Object {
-          "kind": "id",
-          "name": "bar",
-        },
-        "kind": "property",
-        "leadingComments": Array [
-          Object {
-            "raw": " @ert-ignore bar property, ignored because of unknown type ",
-            "type": "commentBlock",
-            "value": "bar property, ignored because of unknown type",
-          },
-        ],
-        "optional": false,
-        "value": undefined,
-      },
-    ],
-    "referenceIdName": "BarProps",
-  },
-}
-`;
-
 exports[`TypeScript: React.ComponentType 1`] = `
 Object {
   "kind": "generic",
@@ -223,6 +157,78 @@ Object {
         },
       },
     ],
+  },
+}
+`;
+
+exports[`TypeScript: Types fallback to raw source when an unsupported type us used (interface) 1`] = `
+Object {
+  "kind": "generic",
+  "name": Object {
+    "kind": "id",
+    "name": "Component",
+    "type": null,
+  },
+  "value": Object {
+    "kind": "object",
+    "members": Array [
+      Object {
+        "key": Object {
+          "kind": "id",
+          "name": "bar",
+        },
+        "kind": "property",
+        "leadingComments": Array [
+          Object {
+            "raw": " bar property docs ",
+            "type": "commentBlock",
+            "value": "bar property docs",
+          },
+        ],
+        "optional": false,
+        "value": Object {
+          "kind": "unsupported",
+          "name": "keyof Bar",
+        },
+      },
+    ],
+    "referenceIdName": "BarProps",
+  },
+}
+`;
+
+exports[`TypeScript: Types fallback to raw source when an unsupported type us used (type) 1`] = `
+Object {
+  "kind": "generic",
+  "name": Object {
+    "kind": "id",
+    "name": "Component",
+    "type": null,
+  },
+  "value": Object {
+    "kind": "object",
+    "members": Array [
+      Object {
+        "key": Object {
+          "kind": "id",
+          "name": "bar",
+        },
+        "kind": "property",
+        "leadingComments": Array [
+          Object {
+            "raw": " bar property docs ",
+            "type": "commentBlock",
+            "value": "bar property docs",
+          },
+        ],
+        "optional": false,
+        "value": Object {
+          "kind": "unsupported",
+          "name": "keyof Bar",
+        },
+      },
+    ],
+    "referenceIdName": "BarProps",
   },
 }
 `;

--- a/packages/extract-react-types/__snapshots__/converters-typescript.test.js.snap
+++ b/packages/extract-react-types/__snapshots__/converters-typescript.test.js.snap
@@ -187,7 +187,7 @@ Object {
         ],
         "optional": false,
         "value": Object {
-          "kind": "unsupported",
+          "kind": "raw",
           "name": "keyof Bar",
         },
       },
@@ -223,7 +223,7 @@ Object {
         ],
         "optional": false,
         "value": Object {
-          "kind": "unsupported",
+          "kind": "raw",
           "name": "keyof Bar",
         },
       },

--- a/packages/extract-react-types/__snapshots__/converters-typescript.test.js.snap
+++ b/packages/extract-react-types/__snapshots__/converters-typescript.test.js.snap
@@ -28,6 +28,39 @@ Object {
 }
 `;
 
+exports[`TypeScript: Ignores unsupported typescript keywords 1`] = `
+Object {
+  "kind": "generic",
+  "name": Object {
+    "kind": "id",
+    "name": "Component",
+    "type": null,
+  },
+  "value": Object {
+    "kind": "object",
+    "members": Array [
+      Object {
+        "key": Object {
+          "kind": "id",
+          "name": "bar",
+        },
+        "kind": "property",
+        "leadingComments": Array [
+          Object {
+            "raw": " @ert-ignore bar property, ignored because of unknown type ",
+            "type": "commentBlock",
+            "value": "bar property, ignored because of unknown type",
+          },
+        ],
+        "optional": false,
+        "value": undefined,
+      },
+    ],
+    "referenceIdName": "BarProps",
+  },
+}
+`;
+
 exports[`TypeScript: React.ComponentType 1`] = `
 Object {
   "kind": "generic",

--- a/packages/extract-react-types/__snapshots__/converters-typescript.test.js.snap
+++ b/packages/extract-react-types/__snapshots__/converters-typescript.test.js.snap
@@ -61,6 +61,39 @@ Object {
 }
 `;
 
+exports[`TypeScript: Ignores unsupported typescript keywords type props 1`] = `
+Object {
+  "kind": "generic",
+  "name": Object {
+    "kind": "id",
+    "name": "Component",
+    "type": null,
+  },
+  "value": Object {
+    "kind": "object",
+    "members": Array [
+      Object {
+        "key": Object {
+          "kind": "id",
+          "name": "bar",
+        },
+        "kind": "property",
+        "leadingComments": Array [
+          Object {
+            "raw": " @ert-ignore bar property, ignored because of unknown type ",
+            "type": "commentBlock",
+            "value": "bar property, ignored because of unknown type",
+          },
+        ],
+        "optional": false,
+        "value": undefined,
+      },
+    ],
+    "referenceIdName": "BarProps",
+  },
+}
+`;
+
 exports[`TypeScript: React.ComponentType 1`] = `
 Object {
   "kind": "generic",

--- a/packages/extract-react-types/converters-typescript.test.js
+++ b/packages/extract-react-types/converters-typescript.test.js
@@ -28,11 +28,11 @@ const TESTS = [
     `
   },
   {
-    name: 'Ignores unsupported typescript keywords',
+    name: 'Types fallback to raw source when an unsupported type us used (interface)',
     typeSystem: 'typescript',
     code: `
       interface BarProps {
-        /* @ert-ignore bar property, ignored because of unknown type */
+        /* bar property docs */
         bar: keyof Bar;
       }
 
@@ -40,11 +40,11 @@ const TESTS = [
     `
   },
   {
-    name: 'Ignores unsupported typescript keywords type props',
+    name: 'Types fallback to raw source when an unsupported type us used (type)',
     typeSystem: 'typescript',
     code: `
       type BarProps = {
-        /* @ert-ignore bar property, ignored because of unknown type */
+        /* bar property docs */
         bar: keyof Bar;
       }
 

--- a/packages/extract-react-types/converters-typescript.test.js
+++ b/packages/extract-react-types/converters-typescript.test.js
@@ -28,6 +28,18 @@ const TESTS = [
     `
   },
   {
+    name: 'Ignores unsupported typescript keywords',
+    typeSystem: 'typescript',
+    code: `
+      interface BarProps {
+        /* @ert-ignore bar property, ignored because of unknown type */
+        bar: keyof Bar;
+      }
+
+      class Component extends React.Component<BarProps> {}
+    `
+  },
+  {
     name: 'React.ComponentType',
     typeSystem: 'typescript',
     code: `

--- a/packages/extract-react-types/converters-typescript.test.js
+++ b/packages/extract-react-types/converters-typescript.test.js
@@ -40,6 +40,18 @@ const TESTS = [
     `
   },
   {
+    name: 'Ignores unsupported typescript keywords type props',
+    typeSystem: 'typescript',
+    code: `
+      type BarProps = {
+        /* @ert-ignore bar property, ignored because of unknown type */
+        bar: keyof Bar;
+      }
+
+      class Component extends React.Component<BarProps> {}
+    `
+  },
+  {
     name: 'React.ComponentType',
     typeSystem: 'typescript',
     code: `

--- a/packages/extract-react-types/src/index.js
+++ b/packages/extract-react-types/src/index.js
@@ -16,7 +16,6 @@ import * as K from './kinds';
 
 export type * from './kinds';
 
-const IGNORE_STATEMENT = '@ert-ignore';
 const converters = {};
 
 function convertObject(path, context) {
@@ -1245,9 +1244,7 @@ function attachComments(source, dest) {
 function parseComment(commentProperty) {
   return commentProperty.map(comment => ({
     type: comment.type === 'CommentLine' ? 'commentLine' : 'commentBlock',
-    value: normalizeComment(comment)
-      .replace(IGNORE_STATEMENT, '')
-      .trim(),
+    value: normalizeComment(comment),
     raw: comment.value
   }));
 }
@@ -1283,7 +1280,7 @@ function convert(path, context) {
     // Fallback to a raw string if property uses a type without a matching converter
     if (propertySignature && propertySignature.node) {
       return {
-        kind: 'unsupported',
+        kind: 'raw',
         name: path.getSource()
       };
     }

--- a/packages/extract-react-types/src/index.js
+++ b/packages/extract-react-types/src/index.js
@@ -1278,7 +1278,7 @@ function convert(path, context) {
   const converter = converters[path.type];
 
   if (!converter) {
-    const propertySignature = path.find(p => p.isTSPropertySignature());
+    const propertySignature = path.find(p => p.isTSPropertySignature() || p.isObjectTypeProperty());
     if (propertySignature && propertySignature.node) {
       const leadingComments = propertySignature.node.leadingComments || [];
       const leadingComment = leadingComments.reduce((accum, comment) => accum + comment.value, '');

--- a/packages/kind2string/src/index.js
+++ b/packages/kind2string/src/index.js
@@ -65,9 +65,10 @@ const converters = {
   custom: (type: any, mode: string): string => type.value.toString(),
   any: (type: K.Any, mode: string): string => type.kind,
   void: (type: K.Void, mode: string): 'undefined' => 'undefined',
-  literal: (type: any, mode: string): string => `${type.kind}`,
+  literal: (type: any, mode: string): string => type.kind,
   mixed: (type: K.Mixed, mode: string): string => type.kind,
   null: (type: K.Null, mode: string): 'null' => 'null',
+  unknown: (type: K.Unknown): string => type.kind,
   logicalExpression: (type, mode: string): string => {
     return `${convert(type.left)} ${type.operator} ${convert(type.right)}`;
   },
@@ -76,9 +77,7 @@ const converters = {
     return `${type.operator}${space}${convert(type.argument)}`;
   },
 
-  id: (type: K.Id, mode: string): string => {
-    return type.name;
-  },
+  id: (type: K.Id, mode: string): string => type.name,
   // TODO - this is not right and needs to be improved
   opaqueType: (type: K.OpaqueType, mode: string): string => {
     return convert(type.id);
@@ -314,6 +313,12 @@ from file: ${convert(type.source, mode)}`
   tuple: (type: K.Tuple, mode: string): string => `[${mapConvertAndJoin(type.types)}]`,
   typeQuery: (type: K.TypeQuery): string => {
     return type.exprName ? `typeof ${type.exprName.name}` : `${type.kind}`;
+  },
+
+  // ERT - Misc
+  unsupported: (type: any): string => {
+    console.log('HERE');
+    return type.name;
   }
 };
 

--- a/packages/kind2string/src/index.js
+++ b/packages/kind2string/src/index.js
@@ -316,10 +316,7 @@ from file: ${convert(type.source, mode)}`
   },
 
   // ERT - Misc
-  unsupported: (type: any): string => {
-    console.log('HERE');
-    return type.name;
-  }
+  raw: (type: any): string => type.name
 };
 
 function convert(type: any, mode: string = 'value') {


### PR DESCRIPTION
Closes: #141

Adds the ability to 'ignore' a property in the case that you want to avoid a ["missing converter error"](https://github.com/atlassian/extract-react-types/issues/150)

To ignore a property, simply prefix the prop with a comment, which includes `@ert-ignore`.

```diff
interface FooProps {
-  // Docs about the bar property here
+  // @ert-ignore Docs about the bar property here
  bar: unknown; 
}

const Foo = props => null;
```