### PR TITLE
New hybrid layout

### DIFF
--- a/.changeset/afraid-socks-give.md
+++ b/.changeset/afraid-socks-give.md
@@ -1,0 +1,5 @@
+---
+'pretty-proptypes': minor
+---
+
+Added a new hybrid layout for displaying props.

--- a/packages/pretty-proptypes/src/HybridLayout/PropEntry.js
+++ b/packages/pretty-proptypes/src/HybridLayout/PropEntry.js
@@ -12,7 +12,7 @@ type PropProps = CommonProps & {
   shapeComponent: ComponentType<CommonProps>
 };
 
-export default class Prop extends Component<PropProps> {
+export default class PropEntry extends Component<PropProps> {
   static defaultProps = {
     shapeComponent: (props: CommonProps) => <PrettyPropType {...props} />
   };
@@ -28,10 +28,11 @@ export default class Prop extends Component<PropProps> {
           css={css`
             width: 100%;
             border-collapse: collapse;
+            margin-top: 40px;
 
             th {
               text-align: left;
-              padding: 4px 8px 4px 0;
+              padding: 4px 16px 4px 8px;
               white-space: nowrap;
               vertical-align: top;
             }
@@ -45,25 +46,35 @@ export default class Prop extends Component<PropProps> {
           <caption
             css={css`
               text-align: left;
-              font-weight: 500;
-              font-size: 1.28571428571em;
-              margin-top: 28px;
-              margin-bottom: 0;
+              margin: 0;
+              font-size: 1em;
             `}
           >
             <Heading
               css={css`
-                font-size: inherit;
-                margin-bottom: 0;
-                padding-bottom: 4px;
+                font-size: 1em;
+                padding-bottom: 8px;
+                border-bottom: 1px solid ${colors.N30};
+                margin-bottom: 4px;
               `}
             >
-              <code>{name}</code>
+              <code
+                css={css`
+                  background-color: ${colors.N20};
+                  color: ${colors.N800};
+                  border-radius: 3px;
+                  padding: 4px 8px;
+                  line-height: 20px;
+                  display: inline-block;
+                `}
+              >
+                {name}
+              </code>
               {required && defaultValue === undefined && (
                 <HeadingRequired
                   css={css`
-                    font-size: initial;
                     margin-left: 1em;
+                    color: ${colors.R400};
                   `}
                 >
                   required
@@ -73,11 +84,11 @@ export default class Prop extends Component<PropProps> {
           </caption>
           <tbody
             css={css`
-              border-bottom: 2px solid ${colors.N20};
+              border-bottom: none;
             `}
           >
             <tr>
-              <th>Description</th>
+              <th scope="row">Description</th>
               <td>
                 {description && (
                   <components.Description>{md([description])}</components.Description>
@@ -86,19 +97,19 @@ export default class Prop extends Component<PropProps> {
             </tr>
             {defaultValue !== undefined && (
               <tr>
-                <th>Default</th>
+                <th scope="row">Default</th>
                 <td>
                   <HeadingDefault>{defaultValue}</HeadingDefault>
                 </td>
               </tr>
             )}
             <tr>
-              <th>Type</th>
+              <th scope="row">Type</th>
               <td
-                css={{
-                  display: 'flex',
-                  flexDirection: 'column'
-                }}
+                css={css`
+                  display: flex;
+                  flex-direction: column;
+                `}
               >
                 <span>
                   <HeadingType>{type}</HeadingType>

--- a/packages/pretty-proptypes/src/HybridLayout/PropEntry.js
+++ b/packages/pretty-proptypes/src/HybridLayout/PropEntry.js
@@ -4,8 +4,9 @@ import { jsx, css } from '@emotion/core';
 import { Fragment, Component, type ComponentType, type Node } from 'react';
 import md from 'react-markings';
 import PrettyPropType from '../PrettyConvert';
-import { HeadingType, HeadingDefault } from '../Prop/Heading';
+import { HeadingType, HeadingDefault, Heading } from '../Prop/Heading';
 import type { CommonProps } from '../types';
+import { colors } from '../components/constants';
 
 type PropProps = CommonProps & {
   shapeComponent: ComponentType<CommonProps>
@@ -23,21 +24,49 @@ export default class Prop extends Component<PropProps> {
 
     return (
       <Fragment>
-        <table>
+        <table
+          css={css`
+            width: 100%;
+            border-collapse: collapse;
+
+            th {
+              text-align: left;
+              padding: 4px 8px 4px 0;
+              white-space: nowrap;
+              vertical-align: top;
+            }
+
+            td {
+              padding: 4px 0 4px 8px;
+              width: 100%;
+            }
+          `}
+        >
           <caption
             css={css`
               text-align: left;
               font-weight: 500;
               font-size: 1.4285714285714286em;
               margin-top: 28px;
-              margin-bottom: 8px;
+              margin-bottom: 0;
             `}
           >
-            <code>{name}</code>
+            <Heading
+              css={css`
+                font-size: inherit;
+                margin-bottom: 0;
+              `}
+            >
+              <code>{name}</code>
+            </Heading>
           </caption>
-          <tbody>
+          <tbody
+            css={css`
+              border-bottom: 2px solid ${colors.N20};
+            `}
+          >
             <tr>
-              <RowLabel>Description</RowLabel>
+              <th>Description</th>
               <td>
                 {description && (
                   <components.Description>{md([description])}</components.Description>
@@ -45,13 +74,13 @@ export default class Prop extends Component<PropProps> {
               </td>
             </tr>
             <tr>
-              <RowLabel>Default</RowLabel>
+              <th>Default</th>
               <td>
                 {defaultValue !== undefined && <HeadingDefault>{defaultValue}</HeadingDefault>}
               </td>
             </tr>
             <tr>
-              <RowLabel>Type</RowLabel>
+              <th>Type</th>
               <td
                 css={{
                   display: 'flex',
@@ -60,6 +89,14 @@ export default class Prop extends Component<PropProps> {
               >
                 <span>
                   <HeadingType>{type}</HeadingType>
+                  {/* <HeadingRequired
+                    css={css`
+                      margin-left: 1em;
+                      font-size: 0.9rem;
+                    `}
+                  >
+                    required
+                  </HeadingRequired> */}
                 </span>
                 <span>
                   <ShapeComponent {...commonProps} />
@@ -72,14 +109,3 @@ export default class Prop extends Component<PropProps> {
     );
   }
 }
-
-const RowLabel = ({ children }) => (
-  <th
-    css={css`
-      text-align: left;
-      padding: 4px 8px 4px 0;
-    `}
-  >
-    {children}
-  </th>
-);

--- a/packages/pretty-proptypes/src/HybridLayout/PropEntry.js
+++ b/packages/pretty-proptypes/src/HybridLayout/PropEntry.js
@@ -1,0 +1,85 @@
+// @flow
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import { Fragment, Component, type ComponentType, type Node } from 'react';
+import md from 'react-markings';
+import PrettyPropType from '../PrettyConvert';
+import { HeadingType, HeadingDefault } from '../Prop/Heading';
+import type { CommonProps } from '../types';
+
+type PropProps = CommonProps & {
+  shapeComponent: ComponentType<CommonProps>
+};
+
+export default class Prop extends Component<PropProps> {
+  static defaultProps = {
+    shapeComponent: (props: CommonProps) => <PrettyPropType {...props} />
+  };
+
+  render() {
+    let { shapeComponent: ShapeComponent, ...commonProps } = this.props;
+
+    let { defaultValue, description, name, required, type, components } = commonProps;
+
+    return (
+      <Fragment>
+        <table>
+          <caption
+            css={css`
+              text-align: left;
+              font-weight: 500;
+              font-size: 1.4285714285714286em;
+              margin-top: 28px;
+              margin-bottom: 8px;
+            `}
+          >
+            <code>{name}</code>
+          </caption>
+          <tbody>
+            <tr>
+              <RowLabel>Description</RowLabel>
+              <td>
+                {description && (
+                  <components.Description>{md([description])}</components.Description>
+                )}
+              </td>
+            </tr>
+            <tr>
+              <RowLabel>Default</RowLabel>
+              <td>
+                {defaultValue !== undefined && <HeadingDefault>{defaultValue}</HeadingDefault>}
+              </td>
+            </tr>
+            <tr>
+              <RowLabel>Type</RowLabel>
+              <td
+                css={{
+                  display: 'flex',
+                  flexDirection: 'column'
+                }}
+              >
+                <span>
+                  <HeadingType>{type}</HeadingType>
+                </span>
+                <span>
+                  <ShapeComponent {...commonProps} />
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </Fragment>
+    );
+  }
+}
+
+const RowLabel = ({ children }) => (
+  <th
+    css={css`
+      text-align: left;
+      padding: 4px 8px 4px 0;
+    `}
+  >
+    {children}
+  </th>
+);

--- a/packages/pretty-proptypes/src/HybridLayout/PropEntry.js
+++ b/packages/pretty-proptypes/src/HybridLayout/PropEntry.js
@@ -4,7 +4,7 @@ import { jsx, css } from '@emotion/core';
 import { Fragment, Component, type ComponentType, type Node } from 'react';
 import md from 'react-markings';
 import PrettyPropType from '../PrettyConvert';
-import { HeadingType, HeadingDefault, Heading } from '../Prop/Heading';
+import { HeadingType, HeadingDefault, Heading, HeadingRequired } from '../Prop/Heading';
 import type { CommonProps } from '../types';
 import { colors } from '../components/constants';
 
@@ -46,7 +46,7 @@ export default class Prop extends Component<PropProps> {
             css={css`
               text-align: left;
               font-weight: 500;
-              font-size: 1.4285714285714286em;
+              font-size: 1.28571428571em;
               margin-top: 28px;
               margin-bottom: 0;
             `}
@@ -55,9 +55,20 @@ export default class Prop extends Component<PropProps> {
               css={css`
                 font-size: inherit;
                 margin-bottom: 0;
+                padding-bottom: 4px;
               `}
             >
               <code>{name}</code>
+              {required && defaultValue === undefined && (
+                <HeadingRequired
+                  css={css`
+                    font-size: initial;
+                    margin-left: 1em;
+                  `}
+                >
+                  required
+                </HeadingRequired>
+              )}
             </Heading>
           </caption>
           <tbody
@@ -73,12 +84,14 @@ export default class Prop extends Component<PropProps> {
                 )}
               </td>
             </tr>
-            <tr>
-              <th>Default</th>
-              <td>
-                {defaultValue !== undefined && <HeadingDefault>{defaultValue}</HeadingDefault>}
-              </td>
-            </tr>
+            {defaultValue !== undefined && (
+              <tr>
+                <th>Default</th>
+                <td>
+                  <HeadingDefault>{defaultValue}</HeadingDefault>
+                </td>
+              </tr>
+            )}
             <tr>
               <th>Type</th>
               <td
@@ -89,14 +102,6 @@ export default class Prop extends Component<PropProps> {
               >
                 <span>
                   <HeadingType>{type}</HeadingType>
-                  {/* <HeadingRequired
-                    css={css`
-                      margin-left: 1em;
-                      font-size: 0.9rem;
-                    `}
-                  >
-                    required
-                  </HeadingRequired> */}
                 </span>
                 <span>
                   <ShapeComponent {...commonProps} />

--- a/packages/pretty-proptypes/src/HybridLayout/index.js
+++ b/packages/pretty-proptypes/src/HybridLayout/index.js
@@ -1,0 +1,97 @@
+// @flow
+
+/* eslint-disable no-underscore-dangle */
+
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import React, { Component, type ComponentType } from 'react';
+
+import type { Components } from '../components';
+import type { CommonProps } from '../types';
+import PropsWrapper from '../Props/Wrapper';
+import getPropTypes from '../getPropTypes';
+import renderPropType from '../PropType';
+import PropEntry from './PropEntry';
+
+type Obj = {
+  kind: 'object',
+  members: Array<any>
+};
+
+type Gen = {
+  kind: 'generic',
+  value: any
+};
+
+type Inter = {
+  kind: 'intersection',
+  types: Array<Obj | Gen>
+};
+
+type DynamicPropsProps = {
+  components?: Components,
+  heading?: string,
+  shouldCollapseProps?: boolean,
+  overrides?: {
+    [string]: ComponentType<CommonProps>
+  },
+  props?: {
+    component?: Obj | Inter
+  },
+  component?: ComponentType<any>
+};
+
+const getProps = props => {
+  if (props && props.component) {
+    return getPropTypes(props.component);
+  }
+  return null;
+};
+
+export default class HybridLayout extends Component<DynamicPropsProps> {
+  render() {
+    let { props, heading, component, components, ...rest } = this.props;
+    if (component) {
+      /* $FlowFixMe the component prop is typed as a component because
+         that's what people pass to Props and the ___types property shouldn't
+         exist in the components types so we're just going to ignore this error */
+      if (component.___types) {
+        props = { type: 'program', component: component.___types };
+      } else {
+        /* eslint-disable-next-line no-console */
+        console.error(
+          'A component was passed to <Props> but it does not have types attached.\n' +
+            'babel-plugin-extract-react-types may not be correctly installed.\n' +
+            '<Props> will fallback to the props prop to display types.'
+        );
+      }
+    }
+
+    if (!components || !components.Description) {
+      components = components || {};
+      components.Description = ({ children }) => (
+        <div
+          css={css`
+            p:first-of-type {
+              margin-top: 0px;
+            }
+            p:last-of-type {
+              margin-bottom: 0px;
+            }
+          `}
+        >
+          {children}
+        </div>
+      );
+    }
+
+    let propTypes = getProps(props);
+    if (!propTypes) return null;
+
+    return (
+      <PropsWrapper heading={heading}>
+        {propTypes.map(propType => renderPropType(propType, { ...rest, components }, PropEntry))}
+      </PropsWrapper>
+    );
+  }
+}

--- a/packages/pretty-proptypes/src/PropType/index.js
+++ b/packages/pretty-proptypes/src/PropType/index.js
@@ -2,13 +2,12 @@
 /* eslint-disable no-param-reassign */
 import React from 'react';
 import convert, { getKind, reduceToObj } from 'kind2string';
-import PropRow from '../PropsTable/PropRow';
-import Prop from '../Prop';
 import allComponents from '../components';
 
 const renderPropType = (
   propType: any,
-  { table = false, overrides = {}, shouldCollapseProps, components }: any,
+  { overrides = {}, shouldCollapseProps, components }: any,
+  PropComponent
 ) => {
   if (!components) {
     components = allComponents;
@@ -56,9 +55,11 @@ const renderPropType = (
     typeValue: propType.value
   };
 
-  return overrides[name] 
-    ? <OverrideComponent {...commonProps} /> 
-    : (table ? <PropRow {...commonProps} />: <Prop {...commonProps} />);
+  return overrides[name] ? (
+    <OverrideComponent {...commonProps} />
+  ) : (
+    <PropComponent {...commonProps} />
+  );
 };
 
 export default renderPropType;

--- a/packages/pretty-proptypes/src/Props/index.js
+++ b/packages/pretty-proptypes/src/Props/index.js
@@ -10,6 +10,8 @@ import PropsWrapper from './Wrapper';
 import getPropTypes from '../getPropTypes';
 import renderPropType from '../PropType';
 
+import Prop from '../Prop';
+
 type Obj = {
   kind: 'object',
   members: Array<any>
@@ -68,7 +70,7 @@ export default class Props extends Component<DynamicPropsProps> {
 
     return (
       <PropsWrapper heading={heading}>
-        {propTypes.map(propType => renderPropType(propType, rest))}
+        {propTypes.map(propType => renderPropType(propType, rest, Prop))}
       </PropsWrapper>
     );
   }

--- a/packages/pretty-proptypes/src/PropsTable/index.js
+++ b/packages/pretty-proptypes/src/PropsTable/index.js
@@ -11,6 +11,7 @@ import type { CommonProps } from '../types';
 import PropsWrapper from '../Props/Wrapper';
 import getPropTypes from '../getPropTypes';
 import renderPropType from '../PropType';
+import PropRow from './PropRow';
 
 type Obj = {
   kind: 'object',
@@ -83,7 +84,7 @@ export default class PropsTable extends Component<DynamicPropsProps> {
               <td>Description</td>
             </tr>
           </thead>
-          {propTypes.map(propType => renderPropType(propType, { table: true, ...rest }))}
+          {propTypes.map(propType => renderPropType(propType, rest, PropRow))}
         </table>
       </PropsWrapper>
     );

--- a/packages/pretty-proptypes/src/components/constants.js
+++ b/packages/pretty-proptypes/src/components/constants.js
@@ -15,5 +15,8 @@ export const colors = {
   R75: '#FFBDAD',
   R50: '#FFEBE6',
   P300: '#6554C0',
-  T300: '#00B8D9'
+  T300: '#00B8D9',
+  R400: '#DE350B',
+  N30: '#EBECF0',
+  N800: '#172B4D'
 };

--- a/packages/pretty-proptypes/src/index.js
+++ b/packages/pretty-proptypes/src/index.js
@@ -2,3 +2,4 @@ export { default as Prop } from './Prop';
 export { default } from './Props';
 export { default as PropsTable } from './PropsTable';
 export { default as components } from './components';
+export { default as HybridLayout } from './HybridLayout';

--- a/stories/FlowComponent.js
+++ b/stories/FlowComponent.js
@@ -6,6 +6,8 @@
 import React from 'react';
 
 type FlowComponentProps = {
+  // This prop is required as it is not optional and has no default
+  requiredProp: any,
   // This prop is a string
   stringProp: string,
   // This prop is a number
@@ -25,9 +27,7 @@ type FlowComponentProps = {
   // This prop is a mixed
   mixedProp: mixed,
   // This prop is a union
-  unionProp: 'hello' | 'world',
-  // This prop is required as it is not optional and has no default
-  requiredProp: any
+  unionProp: 'hello' | 'world'
 };
 
 const FlowComponent = (props: FlowComponentProps) => <p>Hello World</p>;

--- a/stories/FlowComponent.js
+++ b/stories/FlowComponent.js
@@ -25,7 +25,9 @@ type FlowComponentProps = {
   // This prop is a mixed
   mixedProp: mixed,
   // This prop is a union
-  unionProp: 'hello' | 'world'
+  unionProp: 'hello' | 'world',
+  // This prop is required as it is not optional and has no default
+  requiredProp: any
 };
 
 const FlowComponent = (props: FlowComponentProps) => <p>Hello World</p>;

--- a/stories/TypeScriptComponent.tsx
+++ b/stories/TypeScriptComponent.tsx
@@ -10,6 +10,8 @@ interface DummyInterface {
 }
 
 type TypeScriptComponentProps = {
+  // This prop is required as it is not optional and has no default
+  requiredProp: any;
   // This prop is a string
   stringProp: string;
   // This prop is a number
@@ -32,8 +34,6 @@ type TypeScriptComponentProps = {
   unknownProp: unknown;
   // This prop uses an unknown typescript keyword "keyof" and so will result in a bail-out
   unsupportedProp: keyof DummyInterface;
-  // This prop is required as it is not optional and has no default
-  requiredProp: any;
 };
 
 const TypeScriptComponent = (props: TypeScriptComponentProps) => <p>Hello World</p>;

--- a/stories/TypeScriptComponent.tsx
+++ b/stories/TypeScriptComponent.tsx
@@ -32,6 +32,8 @@ type TypeScriptComponentProps = {
   unknownProp: unknown;
   // This prop uses an unknown typescript keyword "keyof" and so will result in a bail-out
   unsupportedProp: keyof DummyInterface;
+  // This prop is required as it is not optional and has no default
+  requiredProp: any;
 };
 
 const TypeScriptComponent = (props: TypeScriptComponentProps) => <p>Hello World</p>;

--- a/stories/layout/Default.stories.js
+++ b/stories/layout/Default.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import Props from 'pretty-proptypes';
+import TypeScriptComponent from '../TypeScriptComponent';
+
+export default {
+  title: 'Example/Layouts',
+  component: Props
+};
+
+const Template = args => args.component;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  component: <Props component={TypeScriptComponent} heading="Primitive types" />
+};

--- a/stories/layout/Default.stories.js
+++ b/stories/layout/Default.stories.js
@@ -4,7 +4,7 @@ import Props from 'pretty-proptypes';
 import TypeScriptComponent from '../TypeScriptComponent';
 
 export default {
-  title: 'Example/Layouts',
+  title: 'Example/Layouts/Default',
   component: Props
 };
 

--- a/stories/layout/Hybrid.stories.js
+++ b/stories/layout/Hybrid.stories.js
@@ -1,7 +1,10 @@
 import React from 'react';
 
 import { HybridLayout } from 'pretty-proptypes';
+import { css, Global } from '@emotion/core';
 import TypeScriptComponent from '../TypeScriptComponent';
+
+import { colors } from '../../packages/pretty-proptypes/src/components/constants';
 
 export default {
   title: 'Example/Layouts/Hybrid',
@@ -14,4 +17,108 @@ export const Hybrid = Template.bind({});
 
 Hybrid.args = {
   component: <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
+};
+
+export const Option1 = Template.bind({});
+
+Option1.args = {
+  component: (
+    <>
+      <Global
+        styles={css`
+          @import 'https://unpkg.com/@atlaskit/css-reset@6.0.5/dist/bundle.css';
+
+          #root {
+            tbody {
+              border: none;
+            }
+
+            h3 {
+              padding-bottom: 8px;
+              border-bottom-color: #ebecf0;
+            }
+
+            h3 code:first-of-type {
+              background-color: rgb(244, 245, 247);
+              color: rgb(23, 43, 77);
+              border-radius: 3px;
+              padding: 4px;
+              font-size: initial;
+            }
+          }
+        `}
+      />
+      <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
+    </>
+  )
+};
+
+export const Option5 = Template.bind({});
+
+Option5.args = {
+  component: (
+    <>
+      <Global
+        styles={css`
+          @import 'https://unpkg.com/@atlaskit/css-reset@6.0.5/dist/bundle.css';
+
+          #root {
+            tbody {
+              background: #fafbfc;
+              border-bottom-color: #ebecf0;
+            }
+
+            h3 {
+              padding-left: 8px;
+              border-bottom-color: #ebecf0;
+            }
+
+            th {
+              padding-left: 8px;
+            }
+          }
+        `}
+      />
+      <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
+    </>
+  )
+};
+
+export const Option8 = Template.bind({});
+
+Option8.args = {
+  component: (
+    <>
+      <Global
+        styles={css`
+          @import 'https://unpkg.com/@atlaskit/css-reset@6.0.5/dist/bundle.css';
+
+          #root {
+            tbody {
+              border: none;
+            }
+
+            th {
+              text-align: right;
+              padding-left: 24px;
+            }
+
+            h3 {
+              padding-bottom: 8px;
+              border-bottom-color: #ebecf0;
+            }
+
+            h3 code:first-of-type {
+              background-color: rgb(244, 245, 247);
+              color: rgb(23, 43, 77);
+              border-radius: 3px;
+              padding: 4px;
+              font-size: initial;
+            }
+          }
+        `}
+      />
+      <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
+    </>
+  )
 };

--- a/stories/layout/Hybrid.stories.js
+++ b/stories/layout/Hybrid.stories.js
@@ -13,109 +13,20 @@ export default {
 
 const Template = args => args.component;
 
-export const Hybrid = Template.bind({});
+export const Base = Template.bind({});
 
-Hybrid.args = {
+Base.args = {
   component: <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
 };
 
-export const Option1 = Template.bind({});
+export const WithReset = Template.bind({});
 
-Option1.args = {
+WithReset.args = {
   component: (
     <>
       <Global
         styles={css`
           @import 'https://unpkg.com/@atlaskit/css-reset@6.0.5/dist/bundle.css';
-
-          #root {
-            tbody {
-              border: none;
-            }
-
-            h3 {
-              padding-bottom: 8px;
-              border-bottom-color: #ebecf0;
-            }
-
-            h3 code:first-of-type {
-              background-color: rgb(244, 245, 247);
-              color: rgb(23, 43, 77);
-              border-radius: 3px;
-              padding: 4px;
-              font-size: initial;
-            }
-          }
-        `}
-      />
-      <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
-    </>
-  )
-};
-
-export const Option5 = Template.bind({});
-
-Option5.args = {
-  component: (
-    <>
-      <Global
-        styles={css`
-          @import 'https://unpkg.com/@atlaskit/css-reset@6.0.5/dist/bundle.css';
-
-          #root {
-            tbody {
-              background: #fafbfc;
-              border-bottom-color: #ebecf0;
-            }
-
-            h3 {
-              padding-left: 8px;
-              border-bottom-color: #ebecf0;
-            }
-
-            th {
-              padding-left: 8px;
-            }
-          }
-        `}
-      />
-      <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
-    </>
-  )
-};
-
-export const Option8 = Template.bind({});
-
-Option8.args = {
-  component: (
-    <>
-      <Global
-        styles={css`
-          @import 'https://unpkg.com/@atlaskit/css-reset@6.0.5/dist/bundle.css';
-
-          #root {
-            tbody {
-              border: none;
-            }
-
-            th {
-              text-align: right;
-              padding-left: 24px;
-            }
-
-            h3 {
-              padding-bottom: 8px;
-              border-bottom-color: #ebecf0;
-            }
-
-            h3 code:first-of-type {
-              background-color: rgb(244, 245, 247);
-              color: rgb(23, 43, 77);
-              border-radius: 3px;
-              padding: 4px;
-              font-size: initial;
-            }
-          }
         `}
       />
       <HybridLayout component={TypeScriptComponent} heading="Primitive types" />

--- a/stories/layout/Hybrid.stories.js
+++ b/stories/layout/Hybrid.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { HybridLayout } from 'pretty-proptypes';
+import TypeScriptComponent from '../TypeScriptComponent';
+
+export default {
+  title: 'Example/Layouts/Hybrid',
+  component: HybridLayout
+};
+
+const Template = args => args.component;
+
+export const Hybrid = Template.bind({});
+
+Hybrid.args = {
+  component: <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
+};

--- a/stories/layout/Table.stories.js
+++ b/stories/layout/Table.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { PropsTable } from 'pretty-proptypes';
+import TypeScriptComponent from '../TypeScriptComponent';
+
+export default {
+  title: 'Example/Layouts',
+  component: PropsTable
+};
+
+const Template = args => args.component;
+
+export const Table = Template.bind({});
+
+Table.args = {
+  component: <PropsTable component={TypeScriptComponent} heading="Primitive types" />
+};

--- a/stories/layout/Table.stories.js
+++ b/stories/layout/Table.stories.js
@@ -4,7 +4,7 @@ import { PropsTable } from 'pretty-proptypes';
 import TypeScriptComponent from '../TypeScriptComponent';
 
 export default {
-  title: 'Example/Layouts',
+  title: 'Example/Layouts/Table',
   component: PropsTable
 };
 


### PR DESCRIPTION
Adding a new hybrid layout for `pretty-proptypes` as well as some stories for the different layouts.

What it looks like by default: 
![image](https://user-images.githubusercontent.com/9005422/110065761-0708a080-7dc4-11eb-8502-39490e95f4f1.png)

What it looks like with `@atlaskit/css-reset`:
![image](https://user-images.githubusercontent.com/9005422/110065788-1a1b7080-7dc4-11eb-90e5-26121ded48d6.png)

