### PR TITLE
PoC: Create new usePropsExplorer hook

### DIFF
--- a/packages/pretty-proptypes/src/index.js
+++ b/packages/pretty-proptypes/src/index.js
@@ -3,3 +3,4 @@ export { default } from './Props';
 export { default as PropsTable } from './PropsTable';
 export { default as components } from './components';
 export { default as HybridLayout } from './HybridLayout';
+export { default as usePropsExplorer } from './usePropsExplorer';

--- a/packages/pretty-proptypes/src/usePropsExplorer/index.js
+++ b/packages/pretty-proptypes/src/usePropsExplorer/index.js
@@ -27,7 +27,5 @@ export default function usePropsExplorer(props) {
 
   let propTypes = getProps(props) || null;
 
-  return {
-    propTypes
-  };
+  return propTypes;
 }

--- a/packages/pretty-proptypes/src/usePropsExplorer/index.js
+++ b/packages/pretty-proptypes/src/usePropsExplorer/index.js
@@ -1,0 +1,33 @@
+import getPropTypes from '../getPropTypes';
+
+const getProps = props => {
+  if (props && props.component) {
+    return getPropTypes(props.component);
+  }
+  return null;
+};
+
+export default function usePropsExplorer(props) {
+  const { component } = props;
+  if (component) {
+    /* $FlowFixMe the component prop is typed as a component because
+         that's what people pass to Props and the ___types property shouldn't
+         exist in the components types so we're just going to ignore this error */
+    if (component.___types) {
+      props = { type: 'program', component: component.___types };
+    } else {
+      /* eslint-disable-next-line no-console */
+      console.error(
+        'A component was passed to <Props> but it does not have types attached.\n' +
+          'babel-plugin-extract-react-types may not be correctly installed.\n' +
+          '<Props> will fallback to the props prop to display types.'
+      );
+    }
+  }
+
+  let propTypes = getProps(props) || null;
+
+  return {
+    propTypes
+  };
+}

--- a/stories/usePropsExplorer.stories.js
+++ b/stories/usePropsExplorer.stories.js
@@ -10,7 +10,7 @@ export default {
 };
 
 const Template = args => {
-  const { propTypes } = usePropsExplorer({ component: TypeScriptComponent });
+  const propTypes = usePropsExplorer({ component: TypeScriptComponent });
 
   return (
     <div>

--- a/stories/usePropsExplorer.stories.js
+++ b/stories/usePropsExplorer.stories.js
@@ -1,0 +1,72 @@
+// @flow
+import React from 'react';
+
+import { usePropsExplorer } from 'pretty-proptypes';
+import FlowComponent from './FlowComponent';
+import TypeScriptComponent from './TypeScriptComponent';
+
+export default {
+  title: 'Example/usePropsExplorer'
+};
+
+const Template = args => {
+  const { propTypes } = usePropsExplorer({ component: TypeScriptComponent });
+
+  return (
+    <div>
+      <h1>usePropsExplorer</h1>
+
+      <p>
+        The usePropsExplorer hook takes a component and will return all prop types for said
+        component. This gives the consumer 100% freedom on how to handle the prop types.
+      </p>
+
+      <table style={{ width: '100%' }}>
+        <thead>
+          <tr>
+            <th align="left" width="200">
+              Prop name
+            </th>
+            <th align="left" width="150">
+              Required?
+            </th>
+            <th align="left" width="150">
+              Type
+            </th>
+            <th align="left" width="200">
+              Default
+            </th>
+            <th align="left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {propTypes.map(prop => (
+            <tr key={prop.key.name}>
+              <td>{prop.key.name}</td>
+              <td>{prop.optional ? 'no' : 'yes'}</td>
+              <td>{prop.value.kind}</td>
+              <td>{prop.default ? prop.default.value : ''}</td>
+              <td>
+                {prop.leadingComments
+                  ? prop.leadingComments.reduce((acc, { value }) => acc.concat(`\n${value}`), '')
+                  : ''}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export const Flow = Template.bind({});
+
+Flow.args = {
+  component: FlowComponent
+};
+
+export const TypeScript = Template.bind({});
+
+TypeScript.args = {
+  component: TypeScriptComponent
+};


### PR DESCRIPTION
### Summary

This is a POC for introducing a `usePropsExplorer` hook to give consumers the option to create a fully customised props table.

**Please note that this is a work in progress - I've only done the changes required to make this work. If this is an approach you'd like to take forward, I will continue this PR!** 

Do let me know what you think!

### Why is this required?

The current library is great and works like a charm, however, there are use-cases where the provided layouts are too restricting. 

At your company, we're building a docs application for our design system and want to be able to sort and group our props into collapsable sections. For example, we want to take all the "aria" attributes from a button and move them into a specific "accessibility" section, all `onX` events into an "event handler" section etc.

In order to do so, we need a list of all the props that we can then manipulate and display in any way we want. 

Currently, this is not possible as there are only three templates to choose from to display the props.

There is a draft PR open (#179) which almost addresses this issue but being able to pass in a "Custom Layout", however, I see this causing issues down the line where you'll have to make sure that all existing layouts still work plus custom layouts are honoured and so on.

This "headless" approach has worked very well for me personally in the past so I thought I'd create a PR showing you this.

This PR could also solve issues such as #141 , #153 and #178 because you could simply tell the consumer "use the hook, build your own thing". Your library would stay highly maintainable, minimal with reasonable defaults.

### Implementation Details

I have created a `usePropsExplorer` hook within the `pretty-proptypes` package that returns an array of the prop types (or `null`). The code is pretty much re-used from the `PropsTable` implementation.

I've created a new storybook story that uses the new hook to display a custom table as example.

### Todo

Should this PR be a desired approach, things left to do include:

- [ ] Refactor the code written and add types using flow
- [ ] Write tests for the new hook
- [ ] Write documentation for the new hook

### Thoughts

Because the hook will be providing all the props, the `PropsTable` implementation could be reduced to use the new hook created. That way it would save code duplication.