### PR TITLE
Add typescript support for quoted keys in types

### DIFF
--- a/.changeset/seven-laws-deliver.md
+++ b/.changeset/seven-laws-deliver.md
@@ -2,4 +2,4 @@
 'extract-react-types': patch
 ---
 
-Allow proper conversion of keys in TypeScript types that are quoted.
+Adds support for string type keys in TypeScript.

--- a/.changeset/seven-laws-deliver.md
+++ b/.changeset/seven-laws-deliver.md
@@ -1,0 +1,5 @@
+---
+'extract-react-types': patch
+---
+
+Allow proper conversion of keys in TypeScript types that are quoted.

--- a/packages/extract-react-types/converters-typescript.test.js
+++ b/packages/extract-react-types/converters-typescript.test.js
@@ -694,11 +694,14 @@ cases(
 test('Typescript quoted property name is converted properly', () => {
   const name = 'quoted';
   const code = stripIndent(`
-    class Component extends React.Component<{ '${name}': string }> {
-      // ...
-    }`);
+    interface Props {
+      /* Type comment for ${name} */
+      '${name}': string;
+    }
+
+    class Component extends React.Component<Props> {}`);
   const typeSystem = 'typescript';
   const result = extractReactTypes(code, typeSystem, __filename);
 
-  expect(result).toHaveProperty(['component', 'members', 0, 'key', 'name'], name);
+  expect(result).toHaveProperty(['component', 'value', 'members', 0, 'key', 'name'], name);
 });

--- a/packages/extract-react-types/converters-typescript.test.js
+++ b/packages/extract-react-types/converters-typescript.test.js
@@ -694,7 +694,7 @@ cases(
 test('Typescript quoted property name is converted properly', () => {
   const name = 'quoted';
   const code = stripIndent(`
-    class Component extends React.Component<{ quoted: string }> {
+    class Component extends React.Component<{ '${name}': string }> {
       // ...
     }`);
   const typeSystem = 'typescript';

--- a/packages/extract-react-types/converters-typescript.test.js
+++ b/packages/extract-react-types/converters-typescript.test.js
@@ -690,3 +690,15 @@ cases(
   },
   TESTS
 );
+
+test('Typescript quoted property name is converted properly', () => {
+  const name = 'quoted';
+  const code = stripIndent(`
+    class Component extends React.Component<{ quoted: string }> {
+      // ...
+    }`);
+  const typeSystem = 'typescript';
+  const result = extractReactTypes(code, typeSystem, __filename);
+
+  expect(result).toHaveProperty(['component', 'members', 0, 'key', 'name'], name);
+});

--- a/packages/extract-react-types/converters-typescript.test.js
+++ b/packages/extract-react-types/converters-typescript.test.js
@@ -691,10 +691,25 @@ cases(
   TESTS
 );
 
-test('Typescript quoted property name is converted properly', () => {
+test('Typescript interface quoted property name is converted properly', () => {
   const name = 'quoted';
   const code = stripIndent(`
     interface Props {
+      /* Type comment for ${name} */
+      '${name}': string;
+    }
+
+    class Component extends React.Component<Props> {}`);
+  const typeSystem = 'typescript';
+  const result = extractReactTypes(code, typeSystem, __filename);
+
+  expect(result).toHaveProperty(['component', 'value', 'members', 0, 'key', 'name'], name);
+});
+
+test('Typescript type quoted property name is converted properly', () => {
+  const name = 'quoted';
+  const code = stripIndent(`
+    type Props = {
       /* Type comment for ${name} */
       '${name}': string;
     }

--- a/packages/extract-react-types/src/converter.js
+++ b/packages/extract-react-types/src/converter.js
@@ -535,12 +535,28 @@ converters.TSTypeLiteral = (path, context): K.Obj => ({
   members: path.get('members').map(memberPath => convert(memberPath, context))
 });
 
-converters.TSPropertySignature = (path, context): K.Property => ({
-  kind: 'property',
-  optional: !!path.node.optional,
-  key: { kind: 'id', name: path.node.key.name },
-  value: convert(path.get('typeAnnotation'), context)
-});
+converters.TSPropertySignature = (path, context): K.Property => {
+  let key = { kind: 'id' };
+  switch (path.node.key.type) {
+    case 'Identifier':
+      key.name = path.node.key.name;
+      break;
+
+    case 'StringLiteral':
+      key.name = path.node.key.value;
+      break;
+
+    default:
+      key.name = undefined;
+  }
+
+  return {
+    kind: 'property',
+    optional: !!path.node.optional,
+    key,
+    value: convert(path.get('typeAnnotation'), context)
+  };
+};
 
 converters.TSTypeAliasDeclaration = (path, context): K.Obj =>
   convert(path.get('typeAnnotation'), context);

--- a/stories/TypeScriptComponent.tsx
+++ b/stories/TypeScriptComponent.tsx
@@ -34,6 +34,8 @@ type TypeScriptComponentProps = {
   unknownProp: unknown;
   // This prop uses an unknown typescript keyword "keyof" and so will result in a bail-out
   unsupportedProp: keyof DummyInterface;
+  // This prop uses hyphens, so the type uses quotations around the key
+  'quoted-prop': any;
 };
 
 const TypeScriptComponent = (props: TypeScriptComponentProps) => <p>Hello World</p>;


### PR DESCRIPTION
Fix for [DST-2574](https://product-fabric.atlassian.net/browse/DST-2574).

Allows the proper conversion of keys in Typescript types that are written using quotes.

**NOTE:** Flow types aren't fixed by this. They render weirdly but in a different way – they show the quotes around the prop name.