### PR TITLE
Export getPropTypes function from pretty-proptypes

### DIFF
--- a/packages/pretty-proptypes/src/index.js
+++ b/packages/pretty-proptypes/src/index.js
@@ -3,3 +3,4 @@ export { default } from './Props';
 export { default as PropsTable } from './PropsTable';
 export { default as components } from './components';
 export { default as HybridLayout } from './HybridLayout';
+export { default as getPropTypes } from './getPropTypes';


### PR DESCRIPTION
Since what I've done in my [previous PR](https://github.com/atlassian/extract-react-types/pull/182) seemed kinda unnecessary I've followed @danieldelcore 's suggestion and just exported the `getPropTypes` function so that consumers can create their own prop tables.