### PR TITLE
Prop table permalink

### DIFF
--- a/.changeset/fifty-carrots-hope.md
+++ b/.changeset/fifty-carrots-hope.md
@@ -1,0 +1,6 @@
+---
+'babel-plugin-extract-react-types': minor
+'pretty-proptypes': minor
+---
+
+Introduces new functionality to enable permalinks to each section of a props list. It's done in a backwards-compatible manner requiring no code changes for a dependency bump, but you might want to double check styles are suitable to the surroundings of where the props are displayed.

--- a/.changeset/fifty-carrots-hope.md
+++ b/.changeset/fifty-carrots-hope.md
@@ -3,4 +3,4 @@
 'pretty-proptypes': minor
 ---
 
-Introduces new functionality to enable permalinks to each section of a props list. It's done in a backwards-compatible manner requiring no code changes for a dependency bump, but you might want to double check styles are suitable to the surroundings of where the props are displayed.
+Introduces new functionality enabling permalinks to each section of a props list. It's done in a backwards-compatible manner requiring no code changes for a dependency bump, but you might want to double check styles are suitable to the surroundings of where the props are displayed.

--- a/packages/babel-plugin-extract-react-types/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-extract-react-types/__snapshots__/index.test.js.snap
@@ -41,7 +41,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow arrow function 1`] = `
@@ -85,7 +86,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow arrow function export default identifier 1`] = `
@@ -132,7 +134,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow arrow function then export 1`] = `
@@ -179,7 +182,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow class 1`] = `
@@ -226,7 +230,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow class declaration export default identifier 1`] = `
@@ -276,7 +281,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow class declaration then export 1`] = `
@@ -326,7 +332,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow default class 1`] = `
@@ -373,7 +380,56 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
+`;
+
+exports[`flow default export with named identifier 1`] = `
+"// @flow
+type Props = {
+  /** this does something */
+  wow: boolean
+};
+
+const CustomComponent = (props: Props) => {
+  return null;
+};
+
+export default CustomComponent;
+CustomComponent.___types = {
+  \\"kind\\": \\"generic\\",
+  \\"value\\": {
+    \\"kind\\": \\"object\\",
+    \\"members\\": [{
+      \\"kind\\": \\"property\\",
+      \\"key\\": {
+        \\"kind\\": \\"id\\",
+        \\"name\\": \\"wow\\"
+      },
+      \\"value\\": {
+        \\"kind\\": \\"boolean\\"
+      },
+      \\"optional\\": false,
+      \\"leadingComments\\": [{
+        \\"type\\": \\"commentBlock\\",
+        \\"value\\": \\"this does something\\",
+        \\"raw\\": \\"* this does something \\"
+      }]
+    }],
+    \\"leadingComments\\": [{
+      \\"type\\": \\"commentLine\\",
+      \\"value\\": \\"@flow\\",
+      \\"raw\\": \\" @flow\\"
+    }],
+    \\"referenceIdName\\": \\"Props\\"
+  },
+  \\"name\\": {
+    \\"kind\\": \\"id\\",
+    \\"name\\": \\"CustomComponent\\",
+    \\"type\\": null
+  }
+};
+CustomComponent.___displayName = \\"CustomComponent\\";"
 `;
 
 exports[`flow default function declaration 1`] = `
@@ -420,7 +476,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow export default function declaration 1`] = `
@@ -465,7 +522,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow forwardRef 1`] = `
@@ -509,7 +567,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow forwardRef function expression 1`] = `
@@ -553,7 +612,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow forwardRef memo arrow function 1`] = `
@@ -597,7 +657,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow forwardRef memo function expression 1`] = `
@@ -641,7 +702,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow function declaration 1`] = `
@@ -685,7 +747,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`flow memo 1`] = `
@@ -729,7 +792,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`typescript default 1`] = `
@@ -754,7 +818,8 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;
 
 exports[`typescript named 1`] = `
@@ -779,5 +844,6 @@ SomeComponent.___types = {
     \\"name\\": \\"SomeComponent\\",
     \\"type\\": null
   }
-};"
+};
+SomeComponent.___displayName = \\"SomeComponent\\";"
 `;

--- a/packages/babel-plugin-extract-react-types/index.js
+++ b/packages/babel-plugin-extract-react-types/index.js
@@ -15,7 +15,7 @@ module.exports = babel => {
           findExportedComponents(programPath, typeSystem, state.file.filename).forEach(
             ({ name, component }) => {
               // TODO: handle when name is null
-              // it will only happen when it's the default export
+              // it will only happen when it's a default and anonymous export
               // generate something like this
               // export default (var someName = function() {}, someName.___types = theTypes, someName)
               if (name !== null) {
@@ -25,6 +25,15 @@ module.exports = babel => {
                       '=',
                       t.memberExpression(t.identifier(name), t.identifier('___types')),
                       babel.parse(`(${JSON.stringify(component)})`).program.body[0].expression
+                    )
+                  )
+                );
+                programPath.node.body.push(
+                  t.expressionStatement(
+                    t.assignmentExpression(
+                      '=',
+                      t.memberExpression(t.identifier(name), t.identifier('___displayName')),
+                      t.stringLiteral(name)
                     )
                   )
                 );

--- a/packages/babel-plugin-extract-react-types/index.test.js
+++ b/packages/babel-plugin-extract-react-types/index.test.js
@@ -259,6 +259,23 @@ let flowCases = [
 
       export { SomeComponent }
       `
+  },
+  {
+    name: 'default export with named identifier',
+    code: `
+    // @flow
+
+    type Props = {
+      /** this does something */
+      wow: boolean
+    };
+    
+    const CustomComponent = (props: Props) => {
+      return null;
+    };  
+
+    export default CustomComponent
+    `
   }
 ];
 

--- a/packages/pretty-proptypes/src/HybridLayout/index.js
+++ b/packages/pretty-proptypes/src/HybridLayout/index.js
@@ -48,9 +48,11 @@ export default class HybridLayout extends Component<DynamicPropsProps> {
             required,
             name,
             type,
+            componentDisplayName,
             components: Comp
           }) => (
             <table
+              {...(componentDisplayName ? { id: `${componentDisplayName}-${name}` } : null)}
               css={css`
                 width: 100%;
                 border-collapse: collapse;
@@ -70,6 +72,11 @@ export default class HybridLayout extends Component<DynamicPropsProps> {
 
                 tbody {
                   border-bottom: none;
+                }
+
+                &:target,
+                &:target > caption {
+                  background: #fffae6;
                 }
               `}
             >

--- a/packages/pretty-proptypes/src/HybridLayout/index.js
+++ b/packages/pretty-proptypes/src/HybridLayout/index.js
@@ -76,7 +76,7 @@ export default class HybridLayout extends Component<DynamicPropsProps> {
 
                 &:target,
                 &:target > caption {
-                  background: #fffae6;
+                  background: #e9f2ff;
                 }
               `}
             >

--- a/packages/pretty-proptypes/src/LayoutRenderer/index.js
+++ b/packages/pretty-proptypes/src/LayoutRenderer/index.js
@@ -55,10 +55,20 @@ const LayoutRenderer: FC<LayoutRendererProps> = ({ props, component, components,
     }
   }
 
+  let renderProps = rest;
+  // ensure displayName passes through, assuming it has been captured
+  // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
+  if (component.___displayName) {
+    renderProps = {
+      ...rest,
+      componentDisplayName: String(component.___displayName)
+    };
+  }
+
   return getProps(resolvedProps).map(propType =>
     renderPropType(
       propType,
-      { ...rest, components: { ...components, PropType: PrettyPropType } },
+      { ...renderProps, components: { ...components, PropType: PrettyPropType } },
       rest.renderType
     )
   );

--- a/packages/pretty-proptypes/src/LayoutRenderer/index.js
+++ b/packages/pretty-proptypes/src/LayoutRenderer/index.js
@@ -58,7 +58,7 @@ const LayoutRenderer: FC<LayoutRendererProps> = ({ props, component, components,
   let renderProps = rest;
   // ensure displayName passes through, assuming it has been captured
   // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
-  if (component.___displayName) {
+  if (component && component.___displayName) {
     renderProps = {
       ...rest,
       componentDisplayName: String(component.___displayName)

--- a/packages/pretty-proptypes/src/PrettyConvert/AddBrackets.js
+++ b/packages/pretty-proptypes/src/PrettyConvert/AddBrackets.js
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { Component, ComponentType, Fragment, type Node } from 'react';
-import ExpanderDefault from '../Components/Expander';
+import ExpanderDefault from '../components/Expander';
 
 type Props = {
   openBracket: string,

--- a/packages/pretty-proptypes/src/Prop/index.js
+++ b/packages/pretty-proptypes/src/Prop/index.js
@@ -12,6 +12,10 @@ const PropTypeWrapper = (props: { children: Node }) => (
   <div
     css={css`
       margin-top: ${gridSize * 4}px;
+
+      &:target {
+        background: #fffae6;
+      }
     `}
     {...props}
   />
@@ -29,10 +33,20 @@ export default class Prop extends Component<PropProps> {
   render() {
     let { shapeComponent: ShapeComponent, ...commonProps } = this.props;
 
-    let { defaultValue, description, name, required, type, components } = commonProps;
+    let {
+      defaultValue,
+      description,
+      name,
+      required,
+      type,
+      components,
+      componentDisplayName
+    } = commonProps;
 
     return (
-      <PropTypeWrapper>
+      <PropTypeWrapper
+        {...(componentDisplayName ? { id: `${componentDisplayName}-${name}` } : null)}
+      >
         <PropTypeHeading name={name} required={required} type={type} defaultValue={defaultValue} />
         {description && <components.Description>{md([description])}</components.Description>}
         <ShapeComponent {...commonProps} />

--- a/packages/pretty-proptypes/src/Prop/index.js
+++ b/packages/pretty-proptypes/src/Prop/index.js
@@ -14,7 +14,7 @@ const PropTypeWrapper = (props: { children: Node }) => (
       margin-top: ${gridSize * 4}px;
 
       &:target {
-        background: #fffae6;
+        background: #e9f2ff;
       }
     `}
     {...props}

--- a/packages/pretty-proptypes/src/Props/index.js
+++ b/packages/pretty-proptypes/src/Props/index.js
@@ -68,9 +68,19 @@ export default class Props extends Component<DynamicPropsProps> {
     let propTypes = getProps(props);
     if (!propTypes) return null;
 
+    let renderProps = rest;
+    // ensure displayName passes through, assuming it has been captured
+    // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
+    if (component.___displayName) {
+      renderProps = {
+        ...rest,
+        componentDisplayName: String(component.___displayName)
+      };
+    }
+
     return (
       <PropsWrapper heading={heading}>
-        {propTypes.map(propType => renderPropType(propType, rest, Prop))}
+        {propTypes.map(propType => renderPropType(propType, renderProps, Prop))}
       </PropsWrapper>
     );
   }

--- a/packages/pretty-proptypes/src/Props/index.js
+++ b/packages/pretty-proptypes/src/Props/index.js
@@ -71,7 +71,7 @@ export default class Props extends Component<DynamicPropsProps> {
     let renderProps = rest;
     // ensure displayName passes through, assuming it has been captured
     // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
-    if (component.___displayName) {
+    if (component && component.___displayName) {
       renderProps = {
         ...rest,
         componentDisplayName: String(component.___displayName)

--- a/packages/pretty-proptypes/src/PropsTable/PropRow.js
+++ b/packages/pretty-proptypes/src/PropsTable/PropRow.js
@@ -24,16 +24,20 @@ export default class Prop extends Component<PropProps> {
      * Other layouts already do.
      * https://github.com/atlassian/extract-react-types/issues/192
      */
-    let { defaultValue, description, name, type, components } = commonProps;
+    let { defaultValue, description, name, type, components, componentDisplayName } = commonProps;
 
     return (
       <Fragment>
         <tbody>
           <tr
+            {...(componentDisplayName ? { id: `${componentDisplayName}-${name}` } : null)}
             valign="top"
             css={{
               '& > td': {
                 padding: '14px 0px'
+              },
+              '&:target': {
+                background: '#FFFAE6'
               }
             }}
           >

--- a/packages/pretty-proptypes/src/PropsTable/PropRow.js
+++ b/packages/pretty-proptypes/src/PropsTable/PropRow.js
@@ -34,10 +34,10 @@ export default class Prop extends Component<PropProps> {
             valign="top"
             css={{
               '& > td': {
-                padding: '14px 0px'
+                padding: '14px 8px'
               },
               '&:target': {
-                background: '#FFFAE6'
+                background: '#e9f2ff'
               }
             }}
           >

--- a/packages/pretty-proptypes/src/PropsTable/index.js
+++ b/packages/pretty-proptypes/src/PropsTable/index.js
@@ -69,6 +69,16 @@ export default class PropsTable extends Component<DynamicPropsProps> {
     let propTypes = getProps(props);
     if (!propTypes) return null;
 
+    let renderProps = rest;
+    // ensure displayName passes through, assuming it has been captured
+    // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
+    if (component.___displayName) {
+      renderProps = {
+        ...rest,
+        componentDisplayName: String(component.___displayName)
+      };
+    }
+
     return (
       <PropsWrapper heading={heading}>
         <table>
@@ -84,7 +94,7 @@ export default class PropsTable extends Component<DynamicPropsProps> {
               <td>Description</td>
             </tr>
           </thead>
-          {propTypes.map(propType => renderPropType(propType, rest, PropRow))}
+          {propTypes.map(propType => renderPropType(propType, renderProps, PropRow))}
         </table>
       </PropsWrapper>
     );

--- a/packages/pretty-proptypes/src/PropsTable/index.js
+++ b/packages/pretty-proptypes/src/PropsTable/index.js
@@ -72,7 +72,7 @@ export default class PropsTable extends Component<DynamicPropsProps> {
     let renderProps = rest;
     // ensure displayName passes through, assuming it has been captured
     // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
-    if (component.___displayName) {
+    if (component && component.___displayName) {
       renderProps = {
         ...rest,
         componentDisplayName: String(component.___displayName)

--- a/packages/pretty-proptypes/src/renderPropType.js
+++ b/packages/pretty-proptypes/src/renderPropType.js
@@ -1,6 +1,6 @@
 // @flow
 /* eslint-disable no-param-reassign */
-import React from 'react';
+import React, { type ComponentType } from 'react';
 import convert, { getKind, reduceToObj } from 'kind2string';
 import allComponents from './components';
 
@@ -39,8 +39,8 @@ const shouldHideProp = comment => {
 
 const renderPropType = (
   propType: any,
-  { overrides = {}, shouldCollapseProps, components = {} }: any,
-  PropComponent
+  { overrides = {}, shouldCollapseProps, components, componentDisplayName = {} }: any,
+  PropComponent?: ComponentType<any>
 ) => {
   components = { ...allComponents, ...components };
 
@@ -92,6 +92,7 @@ const renderPropType = (
       defaultValue={propType.default && convert(propType.default)}
       shouldCollapse={shouldCollapseProps}
       typeValue={propType.value}
+      componentDisplayName={componentDisplayName}
     />
   );
 };

--- a/packages/pretty-proptypes/src/types.js
+++ b/packages/pretty-proptypes/src/types.js
@@ -11,5 +11,7 @@ export type CommonProps = {
   typeValue: Kind,
   type: string,
   shouldCollapse?: boolean,
-  components: Components
+  components: Components,
+  // name of the component being rendered
+  componentDisplayName: string
 };

--- a/stories/layout/LayoutRenderer.stories.js
+++ b/stories/layout/LayoutRenderer.stories.js
@@ -43,7 +43,7 @@ const rowStyles = css`
   }
 
   &:target {
-    background: #fffae6;
+    background: #e9f2ff;
   }
 `;
 

--- a/stories/layout/LayoutRenderer.stories.js
+++ b/stories/layout/LayoutRenderer.stories.js
@@ -41,6 +41,10 @@ const rowStyles = css`
   tbody {
     border-bottom: none;
   }
+
+  &:target {
+    background: #fffae6;
+  }
 `;
 
 const headingStyles = css`
@@ -83,9 +87,13 @@ Base.args = {
           required,
           name,
           type,
-          components
+          components,
+          componentDisplayName
         }) => (
-          <table css={rowStyles}>
+          <table
+            css={rowStyles}
+            {...(componentDisplayName ? { id: `${componentDisplayName}-${name}` } : null)}
+          >
             <caption css={captionStyles}>
               <Heading css={headingStyles}>
                 <code css={headingCodeStyles}>{name}</code>

--- a/stories/layout/Permalink.stories.js
+++ b/stories/layout/Permalink.stories.js
@@ -1,0 +1,64 @@
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+
+import { PropsTable } from 'pretty-proptypes';
+import TypeScriptComponent from '../TypeScriptComponent';
+
+const Template = args => args.component;
+
+export const Example = Template.bind({});
+
+const linksStyles = css`
+  background: black;
+  color: white;
+  display: flex;
+  gap: 0 10px;
+  left: 0;
+  margin: 0;
+  padding: 15px;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  > a {
+    color: white;
+  }
+`;
+
+Example.args = {
+  component: (
+    <div>
+      <h3>
+        <span role="img" aria-label="Hint!">
+          💡
+        </span>{' '}
+        See navigation bar at the bottom
+      </h3>
+      <p css={linksStyles}>
+        <strong>Permalinks: </strong>
+        <a href="#TypeScriptComponent-booleanProp" target="_self">
+          booleanProp
+        </a>
+        &bull;
+        <a href="#TypeScriptComponent-functionProp" target="_self">
+          functionProp
+        </a>
+        &bull;
+        <a href="#TypeScriptComponent-unknownProp" target="_self">
+          unknownProp
+        </a>
+        &bull;
+        <a href="#TypeScriptComponent-stringProp" target="_self">
+          stringProp
+        </a>
+      </p>
+      <div>
+        <PropsTable component={TypeScriptComponent} heading="Primitive types" />
+      </div>
+    </div>
+  )
+};
+
+export default {
+  title: 'Example/Permalinks',
+  component: Example
+};


### PR DESCRIPTION
Allows permalinks to be rendered as each prop displays.

Loom demo: https://www.loom.com/share/85edd8c9a0a2435dba5cff7989651ed0

The demo above was recorded before the correct colour was given by design, so this is a more accurate screenshot of what the final experience can look like:

<img width="1157" alt="Screen Shot 2022-05-12 at 1 45 04 pm" src="https://user-images.githubusercontent.com/9441593/167988944-ef6370b4-59d7-45fd-91f7-ecb9262964a0.png">

Of course, when `LayoutRenderer` is used it's entirely up to the developer to handle styles to whatever visual they want to achieve.