### PR TITLE
Add deprecated styling on deprecated props

### DIFF
--- a/.changeset/angry-pets-hammer.md
+++ b/.changeset/angry-pets-hammer.md
@@ -1,0 +1,5 @@
+---
+'pretty-proptypes': patch
+---
+
+Changed the heading styles for deprecated props and removed "@deprecated" from the prop description.

--- a/packages/pretty-proptypes/src/HybridLayout/index.js
+++ b/packages/pretty-proptypes/src/HybridLayout/index.js
@@ -52,15 +52,11 @@ export default class HybridLayout extends Component<DynamicPropsProps> {
             defaultValue,
             description,
             required,
+            deprecated,
             name,
             type,
-<<<<<<< HEAD
             componentDisplayName,
             components: Comp
-=======
-            components: Comp,
-            deprecated
->>>>>>> 9ba91d5 (add deprecated styling)
           }) => (
             <table
               {...(componentDisplayName ? { id: `${componentDisplayName}-${name}` } : null)}

--- a/packages/pretty-proptypes/src/HybridLayout/index.js
+++ b/packages/pretty-proptypes/src/HybridLayout/index.js
@@ -9,7 +9,13 @@ import { Component, type Node } from 'react';
 import md from 'react-markings';
 import PropsWrapper from '../Props/Wrapper';
 import LayoutRenderer, { type LayoutRendererProps } from '../LayoutRenderer';
-import { HeadingType, HeadingDefault, Heading, HeadingRequired } from '../Prop/Heading';
+import {
+  HeadingType,
+  HeadingDefault,
+  Heading,
+  HeadingRequired,
+  HeadingDeprecated
+} from '../Prop/Heading';
 import { colors } from '../components/constants';
 
 type DynamicPropsProps = LayoutRendererProps & {
@@ -48,8 +54,13 @@ export default class HybridLayout extends Component<DynamicPropsProps> {
             required,
             name,
             type,
+<<<<<<< HEAD
             componentDisplayName,
             components: Comp
+=======
+            components: Comp,
+            deprecated
+>>>>>>> 9ba91d5 (add deprecated styling)
           }) => (
             <table
               {...(componentDisplayName ? { id: `${componentDisplayName}-${name}` } : null)}
@@ -103,6 +114,7 @@ export default class HybridLayout extends Component<DynamicPropsProps> {
                       padding: 4px 8px;
                       line-height: 20px;
                       display: inline-block;
+                      text-decoration: ${deprecated ? 'line-through' : 'none'};
                     `}
                   >
                     {name}
@@ -117,12 +129,28 @@ export default class HybridLayout extends Component<DynamicPropsProps> {
                       required
                     </HeadingRequired>
                   )}
+                  {deprecated && (
+                    <HeadingDeprecated
+                      css={css`
+                        margin-left: 1em;
+                        color: ${colors.N300};
+                      `}
+                    >
+                      deprecated
+                    </HeadingDeprecated>
+                  )}
                 </Heading>
               </caption>
               <tbody>
                 <tr>
                   <th scope="row">Description</th>
-                  <td>{description && <Description>{md([description])}</Description>}</td>
+                  <td>
+                    {description && (
+                      <Description>
+                        {md([description && description.replace('@deprecated', '')])}
+                      </Description>
+                    )}
+                  </td>
                 </tr>
                 {defaultValue !== undefined && (
                   <tr>

--- a/packages/pretty-proptypes/src/Prop/Heading.js
+++ b/packages/pretty-proptypes/src/Prop/Heading.js
@@ -38,6 +38,15 @@ export const HeadingRequired = (props: { children: Node }) => (
   />
 );
 
+export const HeadingDeprecated = (props: { children: Node }) => (
+  <code
+    css={css`
+      color: ${colors.N300};
+    `}
+    {...props}
+  />
+);
+
 export const HeadingType = (props: { children: Node }) => (
   <code
     css={css`
@@ -70,6 +79,7 @@ const Whitespace = () => ' ';
 type PropTypeHeadingProps = {
   name: any,
   required: boolean,
+  deprecated?: boolean,
   type: any,
   // This is probably giving up
   defaultValue?: any
@@ -77,13 +87,16 @@ type PropTypeHeadingProps = {
 
 const PropTypeHeading = (props: PropTypeHeadingProps) => (
   <Heading>
-    <HeadingName>{props.name}</HeadingName>
+    <HeadingName style={{ textDecoration: props.deprecated ? 'line-through' : 'none' }}>
+      {props.name}
+    </HeadingName>
     <Whitespace />
     <HeadingType>{props.type}</HeadingType>
     {props.defaultValue !== undefined && <HeadingDefault> = {props.defaultValue}</HeadingDefault>}
     {props.required && props.defaultValue === undefined ? (
       <HeadingRequired> required</HeadingRequired>
     ) : null}
+    {props.deprecated && <HeadingDeprecated> deprecated</HeadingDeprecated>}
   </Heading>
 );
 

--- a/packages/pretty-proptypes/src/Prop/index.js
+++ b/packages/pretty-proptypes/src/Prop/index.js
@@ -33,6 +33,7 @@ export default class Prop extends Component<PropProps> {
   render() {
     let { shapeComponent: ShapeComponent, ...commonProps } = this.props;
 
+<<<<<<< HEAD
     let {
       defaultValue,
       description,
@@ -49,6 +50,24 @@ export default class Prop extends Component<PropProps> {
       >
         <PropTypeHeading name={name} required={required} type={type} defaultValue={defaultValue} />
         {description && <components.Description>{md([description])}</components.Description>}
+=======
+    let { defaultValue, description, name, required, deprecated, type, components } = commonProps;
+
+    return (
+      <PropTypeWrapper>
+        <PropTypeHeading
+          name={name}
+          required={required}
+          deprecated={deprecated}
+          type={type}
+          defaultValue={defaultValue}
+        />
+        {description && (
+          <components.Description>
+            {md([deprecated ? description.replace('@deprecated', '') : description])}
+          </components.Description>
+        )}
+>>>>>>> 9ba91d5 (add deprecated styling)
         <ShapeComponent {...commonProps} />
       </PropTypeWrapper>
     );

--- a/packages/pretty-proptypes/src/Prop/index.js
+++ b/packages/pretty-proptypes/src/Prop/index.js
@@ -33,12 +33,12 @@ export default class Prop extends Component<PropProps> {
   render() {
     let { shapeComponent: ShapeComponent, ...commonProps } = this.props;
 
-<<<<<<< HEAD
     let {
       defaultValue,
       description,
       name,
       required,
+      deprecated,
       type,
       components,
       componentDisplayName
@@ -48,26 +48,19 @@ export default class Prop extends Component<PropProps> {
       <PropTypeWrapper
         {...(componentDisplayName ? { id: `${componentDisplayName}-${name}` } : null)}
       >
-        <PropTypeHeading name={name} required={required} type={type} defaultValue={defaultValue} />
-        {description && <components.Description>{md([description])}</components.Description>}
-=======
-    let { defaultValue, description, name, required, deprecated, type, components } = commonProps;
-
-    return (
-      <PropTypeWrapper>
         <PropTypeHeading
           name={name}
           required={required}
-          deprecated={deprecated}
           type={type}
           defaultValue={defaultValue}
+          deprecated={deprecated}
         />
         {description && (
           <components.Description>
+            {' '}
             {md([deprecated ? description.replace('@deprecated', '') : description])}
           </components.Description>
         )}
->>>>>>> 9ba91d5 (add deprecated styling)
         <ShapeComponent {...commonProps} />
       </PropTypeWrapper>
     );

--- a/packages/pretty-proptypes/src/renderPropType.js
+++ b/packages/pretty-proptypes/src/renderPropType.js
@@ -97,15 +97,12 @@ const renderPropType = (
       name={name}
       description={description}
       required={!propType.optional}
+      deprecated={shouldDeprecateProp(description)}
       type={getKind(propType.value)}
       defaultValue={propType.default && convert(propType.default)}
       shouldCollapse={shouldCollapseProps}
       typeValue={propType.value}
-<<<<<<< HEAD
       componentDisplayName={componentDisplayName}
-=======
-      deprecated={shouldDeprecateProp(description)}
->>>>>>> 9ba91d5 (add deprecated styling)
     />
   );
 };

--- a/packages/pretty-proptypes/src/renderPropType.js
+++ b/packages/pretty-proptypes/src/renderPropType.js
@@ -5,6 +5,7 @@ import convert, { getKind, reduceToObj } from 'kind2string';
 import allComponents from './components';
 
 const IGNORE_COMMENTS_STARTING_WITH = ['eslint-disable', '@ts-'];
+const DEPRECATE_PROP_THAT_CONTAIN = '@deprecated';
 const HIDE_PROPS_THAT_CONTAIN = ['@internal', '@access private'];
 
 const shouldIgnoreComment = comment => {
@@ -35,6 +36,14 @@ const shouldHideProp = comment => {
   }
 
   return false;
+};
+
+const shouldDeprecateProp = comment => {
+  if (!comment) {
+    return false;
+  }
+
+  return comment.includes(DEPRECATE_PROP_THAT_CONTAIN);
 };
 
 const renderPropType = (
@@ -92,7 +101,11 @@ const renderPropType = (
       defaultValue={propType.default && convert(propType.default)}
       shouldCollapse={shouldCollapseProps}
       typeValue={propType.value}
+<<<<<<< HEAD
       componentDisplayName={componentDisplayName}
+=======
+      deprecated={shouldDeprecateProp(description)}
+>>>>>>> 9ba91d5 (add deprecated styling)
     />
   );
 };

--- a/packages/pretty-proptypes/src/renderPropType.js
+++ b/packages/pretty-proptypes/src/renderPropType.js
@@ -5,7 +5,7 @@ import convert, { getKind, reduceToObj } from 'kind2string';
 import allComponents from './components';
 
 const IGNORE_COMMENTS_STARTING_WITH = ['eslint-disable', '@ts-'];
-const DEPRECATE_PROP_THAT_CONTAIN = '@deprecated';
+const DEPRECATE_PROPS_THAT_CONTAIN = '@deprecated';
 const HIDE_PROPS_THAT_CONTAIN = ['@internal', '@access private'];
 
 const shouldIgnoreComment = comment => {
@@ -43,7 +43,7 @@ const shouldDeprecateProp = comment => {
     return false;
   }
 
-  return comment.includes(DEPRECATE_PROP_THAT_CONTAIN);
+  return comment.includes(DEPRECATE_PROPS_THAT_CONTAIN);
 };
 
 const renderPropType = (

--- a/packages/pretty-proptypes/src/types.js
+++ b/packages/pretty-proptypes/src/types.js
@@ -12,6 +12,10 @@ export type CommonProps = {
   type: string,
   shouldCollapse?: boolean,
   components: Components,
+<<<<<<< HEAD
   // name of the component being rendered
   componentDisplayName: string
+=======
+  deprecated?: boolean
+>>>>>>> 9ba91d5 (add deprecated styling)
 };

--- a/packages/pretty-proptypes/src/types.js
+++ b/packages/pretty-proptypes/src/types.js
@@ -7,15 +7,12 @@ export type CommonProps = {
   defaultValue?: string,
   description?: string,
   required: boolean,
+  deprecated?: boolean,
   name: string,
   typeValue: Kind,
   type: string,
   shouldCollapse?: boolean,
   components: Components,
-<<<<<<< HEAD
   // name of the component being rendered
   componentDisplayName: string
-=======
-  deprecated?: boolean
->>>>>>> 9ba91d5 (add deprecated styling)
 };

--- a/stories/TypeScriptComponent.tsx
+++ b/stories/TypeScriptComponent.tsx
@@ -41,6 +41,11 @@ type TypeScriptComponentProps = {
   // @internal
   hideProp: Boolean;
   nocomment: boolean;
+  /**
+   * @deprecated
+   * This prop is deprecated
+   */
+  deprecatedProp: boolean;
 };
 
 const TypeScriptComponent = (props: TypeScriptComponentProps) => <p>Hello World</p>;

--- a/stories/TypeScriptComponent.tsx
+++ b/stories/TypeScriptComponent.tsx
@@ -64,7 +64,8 @@ TypeScriptComponent.defaultProps = {
   anyProp: 'any',
   unionProp: 'hello',
   unknownProp: 'hello',
-  unsupportedProp: 'text'
+  unsupportedProp: 'text',
+  deprecatedProp: true
 };
 
 export default TypeScriptComponent;

--- a/stories/layout/LayoutRenderer.stories.js
+++ b/stories/layout/LayoutRenderer.stories.js
@@ -8,6 +8,7 @@ import {
   Heading,
   HeadingDefault,
   HeadingRequired,
+  HeadingDeprecated,
   HeadingType
 } from '../../packages/pretty-proptypes/src/Prop/Heading';
 import { colors } from '../../packages/pretty-proptypes/src/components/constants';
@@ -41,10 +42,6 @@ const rowStyles = css`
   tbody {
     border-bottom: none;
   }
-
-  &:target {
-    background: #e9f2ff;
-  }
 `;
 
 const headingStyles = css`
@@ -74,6 +71,11 @@ const headingRequiredStyles = css`
   color: ${colors.R400};
 `;
 
+const headingDeprecatedStyles = css`
+  margin-left: 1em;
+  color: ${colors.N300};
+`;
+
 Base.args = {
   component: (
     <div>
@@ -88,17 +90,22 @@ Base.args = {
           name,
           type,
           components,
-          componentDisplayName
+          deprecated
         }) => (
-          <table
-            css={rowStyles}
-            {...(componentDisplayName ? { id: `${componentDisplayName}-${name}` } : null)}
-          >
+          <table css={rowStyles}>
             <caption css={captionStyles}>
               <Heading css={headingStyles}>
-                <code css={headingCodeStyles}>{name}</code>
+                <code
+                  css={headingCodeStyles}
+                  style={{ textDecoration: deprecated ? 'line-through' : 'none' }}
+                >
+                  {name}
+                </code>
                 {required && defaultValue === undefined && (
                   <HeadingRequired css={headingRequiredStyles}>required</HeadingRequired>
+                )}
+                {deprecated && (
+                  <HeadingDeprecated css={headingDeprecatedStyles}>deprecated</HeadingDeprecated>
                 )}
               </Heading>
             </caption>
@@ -106,7 +113,9 @@ Base.args = {
               <tr>
                 <th scope="row">Description</th>
                 <td>
-                  <components.Description>{md([description])}</components.Description>
+                  <components.Description>
+                    {md([description && description.replace('@deprecated', '')])}
+                  </components.Description>
                 </td>
               </tr>
               {defaultValue !== undefined && (


### PR DESCRIPTION
Added deprecated styling onto deprecated props in

- Default layout
<img width="657" alt="Screen Shot 2022-05-12 at 3 18 57 pm" src="https://user-images.githubusercontent.com/32695390/167997280-6be4cf00-266f-418d-aa02-911dc0a4e9f6.png">

- Hybrid layout
<img width="668" alt="Screen Shot 2022-05-12 at 3 19 20 pm" src="https://user-images.githubusercontent.com/32695390/167997642-ac55cfcb-babf-4657-a282-4cc948d6132b.png">
<img width="783" alt="Screen Shot 2022-05-12 at 3 19 46 pm" src="https://user-images.githubusercontent.com/32695390/167997580-f662ba67-8fed-4a23-af82-106bf461f1d1.png">

- LayoutRenderer (most styles were added in the story example)
<img width="501" alt="Screen Shot 2022-05-12 at 3 20 45 pm" src="https://user-images.githubusercontent.com/32695390/167997617-375a4c8a-1ad1-482a-ad5a-b44927639c32.png">
