### PR TITLE
Add "sortProps" and "requiredPropsFirst" props to LayoutRenderer

### DIFF
--- a/.changeset/twenty-sheep-tie.md
+++ b/.changeset/twenty-sheep-tie.md
@@ -1,0 +1,5 @@
+---
+'pretty-proptypes': minor
+---
+
+Adds "sortProps" and "requiredPropsFirst" props to LayoutRenderer and HybridLayout

--- a/packages/pretty-proptypes/src/HybridLayout/index.js
+++ b/packages/pretty-proptypes/src/HybridLayout/index.js
@@ -40,13 +40,22 @@ const Description = ({ children }: { children: Node }) => (
 
 export default class HybridLayout extends Component<DynamicPropsProps> {
   render() {
-    const { props, heading, component, shouldCollapseProps } = this.props;
+    const {
+      props,
+      heading,
+      component,
+      shouldCollapseProps,
+      requiredPropsFirst,
+      sortProps
+    } = this.props;
 
     return (
       <PropsWrapper heading={heading}>
         <LayoutRenderer
           component={component}
           props={props}
+          requiredPropsFirst={requiredPropsFirst}
+          sortProps={sortProps}
           renderType={({
             typeValue,
             defaultValue,

--- a/packages/pretty-proptypes/src/LayoutRenderer/index.test.js
+++ b/packages/pretty-proptypes/src/LayoutRenderer/index.test.js
@@ -1,0 +1,83 @@
+// @flow
+
+import { mount, configure } from 'enzyme';
+import React from 'react';
+import Adapter from 'enzyme-adapter-react-16';
+import { extractReactTypes } from 'extract-react-types';
+import LayoutRenderer from './index';
+
+configure({ adapter: new Adapter() });
+
+const assembleComponent = (propTypes, defaultProps, type = 'typescript') => {
+  let file = `
+  class Component extends React.Component<${propTypes}> {
+    defaultProps = ${defaultProps}
+  }`;
+  return extractReactTypes(file, type);
+};
+
+test('requiredPropsFirst should place required props in front of other props', () => {
+  const propTypes = assembleComponent(
+    `{
+      /**
+       * Required, but with a default value. Should be rendered second
+       */ 
+      a: number,
+      /** 
+       * Optional, should be rendered third
+       */ 
+      b?: string,
+      /**
+       * Required, no default. Should be rendered first
+       */
+      c: boolean,  
+    }`,
+    `{a: 1}`
+  );
+
+  const order = [];
+
+  // $FlowFixMe - deliberately no children
+  mount(
+    <LayoutRenderer
+      props={propTypes}
+      requiredPropsFirst
+      renderType={props => {
+        order.push(props.name);
+        return <div />;
+      }}
+    />
+  );
+
+  expect(order[0]).toEqual('c');
+});
+
+test('sortProps should run sort function before applying requiredPropsFirst', () => {
+  const propTypes = assembleComponent(
+    `{
+      c?: number,
+      b?: string,
+      a?: boolean,  
+      e: string,
+      d: string,
+    }`,
+    `{a: 1}`
+  );
+
+  const order = [];
+
+  // $FlowFixMe - deliberately no children
+  mount(
+    <LayoutRenderer
+      props={propTypes}
+      sortProps={(propA, propB) => propA.key.name.localeCompare(propB.key.name)}
+      requiredPropsFirst
+      renderType={props => {
+        order.push(props.name);
+        return <div />;
+      }}
+    />
+  );
+
+  expect(order[0]).toEqual('d');
+});

--- a/stories/layout/Hybrid.stories.js
+++ b/stories/layout/Hybrid.stories.js
@@ -13,8 +13,14 @@ const Template = args => args.component;
 
 export const Base = Template.bind({});
 
+const props = {
+  component: TypeScriptComponent,
+  requiredPropsFirst: true,
+  heading: 'Primitive types'
+};
+
 Base.args = {
-  component: <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
+  component: <HybridLayout {...props} />
 };
 
 export const WithReset = Template.bind({});
@@ -27,7 +33,7 @@ WithReset.args = {
           @import 'https://unpkg.com/@atlaskit/css-reset@6.0.5/dist/bundle.css';
         `}
       />
-      <HybridLayout component={TypeScriptComponent} heading="Primitive types" />
+      <HybridLayout {...props} />
     </>
   )
 };

--- a/stories/layout/LayoutRenderer.stories.js
+++ b/stories/layout/LayoutRenderer.stories.js
@@ -82,6 +82,7 @@ Base.args = {
       <h2>Primitive types</h2>
       <LayoutRenderer
         component={TypeScriptComponent}
+        requiredPropsFirst
         renderType={({
           typeValue,
           defaultValue,


### PR DESCRIPTION
Adds two props to LayoutRenderer:
- **sortProps:** provide a comparison function and it'll be used to sort the props displayed by LayoutRenderer
- **requiredPropsFirst:** Explicit support for the most common sorting approach; will put required props first

If both are used, the custom sort is done first, and then required props are sorted to the top.

I have not added support in the non-LayoutRenderer views in `pretty-proptypes`, as they're likely to be moved to LayoutRenderer in future.