### PR TITLE
Alternatively obtain componentDisplayName from props object

### DIFF
--- a/.changeset/tall-yaks-matter.md
+++ b/.changeset/tall-yaks-matter.md
@@ -1,0 +1,5 @@
+---
+'pretty-proptypes': patch
+---
+
+Permalink generation should also work now when `extract-react-types` is used.

--- a/packages/pretty-proptypes/src/LayoutRenderer/index.js
+++ b/packages/pretty-proptypes/src/LayoutRenderer/index.js
@@ -10,6 +10,7 @@ import type { Components } from '../components';
 import getPropTypes from '../getPropTypes';
 import renderPropType from '../renderPropType';
 import PrettyPropType from '../PrettyConvert';
+import { getComponentDisplayName } from '../utils';
 
 type Obj = {
   kind: 'object',
@@ -56,12 +57,11 @@ const LayoutRenderer: FC<LayoutRendererProps> = ({ props, component, components,
   }
 
   let renderProps = rest;
-  // ensure displayName passes through, assuming it has been captured
-  // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
-  if (component && component.___displayName) {
+  const componentDisplayName = getComponentDisplayName(component || (props || {}).component);
+  if (typeof componentDisplayName === 'string') {
     renderProps = {
       ...rest,
-      componentDisplayName: String(component.___displayName)
+      componentDisplayName
     };
   }
 

--- a/packages/pretty-proptypes/src/Props/index.js
+++ b/packages/pretty-proptypes/src/Props/index.js
@@ -9,6 +9,7 @@ import type { CommonProps } from '../types';
 import PropsWrapper from './Wrapper';
 import getPropTypes from '../getPropTypes';
 import renderPropType from '../renderPropType';
+import { getComponentDisplayName } from '../utils';
 
 import Prop from '../Prop';
 
@@ -69,12 +70,12 @@ export default class Props extends Component<DynamicPropsProps> {
     if (!propTypes) return null;
 
     let renderProps = rest;
-    // ensure displayName passes through, assuming it has been captured
-    // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
-    if (component && component.___displayName) {
+    // $FlowFixMe types are not exactly correct here ... sadly :/
+    const componentDisplayName = getComponentDisplayName(component || (props || {}).component);
+    if (typeof componentDisplayName === 'string') {
       renderProps = {
         ...rest,
-        componentDisplayName: String(component.___displayName)
+        componentDisplayName
       };
     }
 

--- a/packages/pretty-proptypes/src/PropsTable/index.js
+++ b/packages/pretty-proptypes/src/PropsTable/index.js
@@ -11,6 +11,7 @@ import type { CommonProps } from '../types';
 import PropsWrapper from '../Props/Wrapper';
 import getPropTypes from '../getPropTypes';
 import renderPropType from '../renderPropType';
+import { getComponentDisplayName } from '../utils';
 import PropRow from './PropRow';
 
 type Obj = {
@@ -70,12 +71,12 @@ export default class PropsTable extends Component<DynamicPropsProps> {
     if (!propTypes) return null;
 
     let renderProps = rest;
-    // ensure displayName passes through, assuming it has been captured
-    // $FlowFixMe as mentioned above, the typing for `component` is a bit off here...
-    if (component && component.___displayName) {
+    // $FlowFixMe types are not exactly correct here ... sadly :/
+    const componentDisplayName = getComponentDisplayName(component || (props || {}).component);
+    if (typeof componentDisplayName === 'string') {
       renderProps = {
         ...rest,
-        componentDisplayName: String(component.___displayName)
+        componentDisplayName
       };
     }
 

--- a/packages/pretty-proptypes/src/utils.js
+++ b/packages/pretty-proptypes/src/utils.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-underscore-dangle */
+// @flow strict-local
+
+// eslint-disable-next-line import/prefer-default-export
+export const getComponentDisplayName = (
+  data:
+    | {
+        ___displayName?: string
+      }
+    | {
+        name?: {
+          name?: string
+        }
+      }
+    | void
+): string | void => {
+  // ensure displayName passes through, assuming it has been captured by Babel
+  if (data && data.___displayName) {
+    return String(data.___displayName);
+    // or it might be obtainable from the converter logic in `packages/extract-react-types/src/converter`
+  } else if (data && data.name && data.name.name) {
+    return String(data.name.name);
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
Through some intense debugging 😅 I realised the current output from the converter in `packages/extract-react-types/src/converter` already includes the information about the identifier declaring the props. See image below:

<img width="699" alt="demo" src="https://user-images.githubusercontent.com/9441593/168570247-c391c0a4-6761-4d32-8133-3ae621280526.png">

Given the very limited testing for this section of the code I had to go seriously defensive with any changes, so it should work under the expected object formats, falling back to an (expected) `undefined` display name values (already handled in code, [from my previous PR](https://github.com/atlassian/extract-react-types/pull/224/))

Not exactly ergonomic ... 😅 but I managed to test this by changing the source under `node_modules` for my atlassian-frontend installation and can confirm it's working as intended.
