### PR TITLE
remove root package name from project package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "extract-react-types-mono-repo",
+  "name": "",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
**Why?**
This avoids a possible vuln where someone might publish malicious code to npm using this package name and it is accidentally installed by an unsuspecting developer. 