### PR TITLE
Rollback version bump

### DIFF
--- a/.changeset/wise-trains-run.md
+++ b/.changeset/wise-trains-run.md
@@ -1,0 +1,7 @@
+---
+'extract-react-types-loader': patch
+'kind2string': patch
+'pretty-proptypes': patch
+---
+
+Rollback to latest published version of extract-react-types

--- a/packages/extract-react-types-loader/package.json
+++ b/packages/extract-react-types-loader/package.json
@@ -14,6 +14,6 @@
     "documentation"
   ],
   "dependencies": {
-    "extract-react-types": "^0.30.5"
+    "extract-react-types": "^0.30.3"
   }
 }

--- a/packages/kind2string/package.json
+++ b/packages/kind2string/package.json
@@ -12,7 +12,7 @@
   ],
   "devDependencies": {
     "babel-jest": "^27.0.0",
-    "extract-react-types": "^0.30.5"
+    "extract-react-types": "^0.30.3"
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4"

--- a/packages/pretty-proptypes/package.json
+++ b/packages/pretty-proptypes/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "devDependencies": {
-    "extract-react-types": "^0.30.5",
+    "extract-react-types": "^0.30.3",
     "jsdom": "^26.1.0",
     "react": "^16.3.1",
     "react-addons-test-utils": "^15.6.2",


### PR DESCRIPTION
New version seems to be unable to publish because we used the not-yet-published version as a dependency for other packages:
https://github.com/atlassian/extract-react-types/actions/runs/16161623084/job/45614268679