### PR TITLE
Try using node_auth_token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The problem: https://github.com/atlassian/extract-react-types/actions/runs/16162450375/job/45616610034
The Release action fails with an error. The error is very misleading - it tries publishing 0.30.4 version of the package and then fails with 404 stating that version 0.30.4 is not found on NPM (which doesn't make much sense - we are publishing exactly this one).

A possible solution implemented in this PR was suggested on several github issues is to replace npm_token with node_auth_token https://github.com/changesets/action/issues/321#issuecomment-2805101456